### PR TITLE
adding support for json file with size more than 520 bytes

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -4,6 +4,7 @@ package mimetype
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 )
 
@@ -24,6 +25,16 @@ func DetectReader(r io.Reader) (mime, extension string, err error) {
 	in = in[:n]
 
 	mime, ext := Detect(in)
+
+	if err == nil { //file size is more than 520 bytes
+		if rootNode, isPresent := FullDataNodesMap[mime]; isPresent {
+			if remainingData, err := ioutil.ReadAll(r); err == nil {
+				allData := append(in, remainingData...) //apend the data to previous 520 bytes to form complete file content
+				n := Root.match(allData, rootNode)
+				mime, ext = n.Mime(), n.Extension()
+			}
+		}
+	}
 	return mime, ext, nil
 }
 

--- a/testdata/a.json
+++ b/testdata/a.json
@@ -1,24 +1,39 @@
 {
-  "firstName": "John",
-  "lastName": "Smith",
-  "age": 25,
-  "address": {
-    "streetAddress": "21 2nd Street",
-    "city": "New York",
-    "state": "NY",
-    "postalCode": "10021"
-  },
-  "phoneNumber": [
-    {
-      "type": "home",
-      "number": "212 555-1234"
-    },
-    {
-      "type": "fax",
-      "number": "646 555-4567"
-    }
-  ],
-  "gender": {
-    "type": "male"
-  }
+	"AllowIP": [
+		"127.0.0.1"
+	],
+	"AllowRawReadingFromPath": [
+		"c:/j(/|/.*)?$",
+		"./.*"
+	],
+	"ArgsLoggingExclude": [],
+	"Binding": "0.0.0.0:53638",
+	"DebugLevel": "debug",
+	"DebugLevel1": "error",
+	"EnableAuthentication": true,
+	"EnableIPAcl": false,
+	"LogMaxAge": 10,
+	"LogMaxBackups": 3,
+	"LogMaxSize": 5,
+	"RawReadingFilesEnabled": false,
+	"RawReadingMaxKbytes": 4096,
+	"SQL": {
+		"BackupCount": 5,
+		"BackupDir": "backups",
+		"BackupPeriod": 1,
+		"Queries": [
+			{
+				"Name": "migrations",
+				"Query": "SELECT * FROM ALALA;"
+			}
+		]
+	},
+	"SvcDescription": "testing environment",
+	"SvcDisplayName": "testing",
+	"SvcNameSuffix": "",
+	"TemplateData": {},
+	"WorkerPool": {
+		"Max": 5,
+		"Timeout": 5
+	}
 }

--- a/tree.go
+++ b/tree.go
@@ -1,6 +1,12 @@
 package mimetype
 
-import "github.com/gabriel-vasile/mimetype/matchers"
+import (
+	"github.com/gabriel-vasile/mimetype/matchers"
+)
+
+func init() {
+	initFullDataNodesMap()
+}
 
 // Root is a matcher which passes for any slice of bytes.
 // When a matcher passes the check, the children matchers are tried in order to
@@ -71,3 +77,22 @@ var (
 	Avi       = NewNode("video/x-msvideo", "avi", matchers.Avi)
 	Flv       = NewNode("video/x-flv", "flv", matchers.Flv)
 )
+
+var FullDataNodesMap map[string]*Node
+
+func initFullDataNodesMap() {
+	AddNodeNeedingFullData(Txt, Json)
+}
+
+func AddNodeNeedingFullData(root *Node, child ...*Node) {
+	if FullDataNodesMap == nil {
+		FullDataNodesMap = make(map[string]*Node, 0)
+	}
+	if rootNode, ok := FullDataNodesMap[root.Mime()]; ok {
+		rootNode.Append(child...)
+		FullDataNodesMap[rootNode.Mime()] = rootNode
+	} else {
+		tmpNode := NewNode(root.Mime(), root.Extension(), root.matchFunc, child...)
+		FullDataNodesMap[tmpNode.Mime()] = tmpNode
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1,0 +1,48 @@
+package mimetype
+
+import (
+	"testing"
+
+	"github.com/gabriel-vasile/mimetype/matchers"
+)
+
+func TestAddNodeNeedingFullData(t *testing.T) {
+	testNode1 := NewNode("test/node1; charset=utf-8", "test", matchers.False,
+		Svg, X3d, Kml, Collada, Gml, Gpx)
+	testNode2 := NewNode("test/node2; charset=utf-8", "test", matchers.False,
+		Xlsx, Docx, Pptx, Epub, Jar)
+	defer func() { //clearing global map after test is executed
+		delete(FullDataNodesMap, testNode1.Mime())
+		delete(FullDataNodesMap, testNode2.Mime())
+	}()
+	type args struct {
+		root  *Node
+		child []*Node
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedLen int
+	}{
+		{name: "add1node",
+			args:        args{root: testNode1, child: []*Node{Svg}},
+			expectedLen: 1,
+		},
+		{name: "add2nodes",
+			args:        args{root: testNode1, child: []*Node{Gml}},
+			expectedLen: 2,
+		},
+		{name: "add3NodesAtATime",
+			args:        args{root: testNode2, child: []*Node{Xlsx, Docx, Pptx}},
+			expectedLen: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddNodeNeedingFullData(tt.args.root, tt.args.child...)
+			if len(FullDataNodesMap[tt.args.root.Mime()].children) != tt.expectedLen {
+				t.Errorf("expected map-length=%d, got map-length=%d", tt.expectedLen, len(FullDataNodesMap[tt.args.root.Mime()].children))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi,
This PR fixes #12 
The solution poroposed is as follows:
There will be always types which may need full data to fully recognize them.
So the PR adds support for such types by adding them to exception list.
So whenever their parent type is detetced and file size is more than 520 bytes,
check is done for the exception list for that parent. 
If still no match is found then mime type of the parent is returned.
User also can add their custom mime types(if any) to this list and start using the package without restricting to 520 bytes size limit.

Changes done:
exception list in the form of hash map is added.
size of test json file(a.json) is made greater than 520 bytes.
Test cases are added for the newly written function for 100% coverage.
Code is formatted using vscode editor.
100% code coverage with all test cases passing

Regards.

