### PR TITLE
Add go version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/gabriel-vasile/mimetype
+
+go 1.12


### PR DESCRIPTION
On go1.13, every time `go build` or `go test` is run, the `go.mod`
file is automatically populated with a Go version. It will be set
to the current release (go1.13) if no existing version is present.

The version of Go in go.mod shall be the minimum version of Go that
the module supports.

P.S:
Pardon my OCD by it is little unsettling to have to explicitly not
check in the go.mod file in the commit every time. I have set the
version to `go1.12` as travis tests on master and PRs are run
against that version.