### PR TITLE
Trim whitespace from start of HTML/XML files

### DIFF
--- a/internal/matchers/text.go
+++ b/internal/matchers/text.go
@@ -136,11 +136,19 @@ func Txt(in []byte) bool {
 
 // Html matches a Hypertext Markup Language file.
 func Html(in []byte) bool {
+	in = trimLWS(in)
+	if len(in) == 0 {
+		return false
+	}
 	return detect(in, htmlSigs)
 }
 
 // Xml matches an Extensible Markup Language file.
 func Xml(in []byte) bool {
+	in = trimLWS(in)
+	if len(in) == 0 {
+		return false
+	}
 	return detect(in, xmlSigs)
 }
 

--- a/mime_test.go
+++ b/mime_test.go
@@ -97,6 +97,7 @@ var files = map[string]*node{
 
 	// source code
 	"html.html":         html,
+	"html.withbr.html":  html,
 	"svg.svg":           svg,
 	"svg.1.svg":         svg,
 	"txt.txt":           txt,
@@ -138,18 +139,18 @@ var files = map[string]*node{
 	"eot.eot":     eot,
 
 	// XML and subtypes of XML
-	"xml.xml":   xml,
-	"kml.kml":   kml,
-	"xlf.xlf":   xliff,
-	"dae.dae":   collada,
-	"gml.gml":   gml,
-	"gpx.gpx":   gpx,
-	"tcx.tcx":   tcx,
-	"x3d.x3d":   x3d,
-	"amf.amf":   amf,
-	"3mf.3mf":   threemf,
-	"rss.rss":   rss,
-	"atom.atom": atom,
+	"xml.withbr.xml": xml,
+	"kml.kml":        kml,
+	"xlf.xlf":        xliff,
+	"dae.dae":        collada,
+	"gml.gml":        gml,
+	"gpx.gpx":        gpx,
+	"tcx.tcx":        tcx,
+	"x3d.x3d":        x3d,
+	"amf.amf":        amf,
+	"3mf.3mf":        threemf,
+	"rss.rss":        rss,
+	"atom.atom":      atom,
 
 	"shp.shp": shp,
 	"shx.shx": shx,

--- a/testdata/html.withbr.html
+++ b/testdata/html.withbr.html
@@ -1,0 +1,14 @@
+
+<!DOCTYPE html>
+<html>
+  <head><!--[if lt IE 9]><script language="javascript" type="text/javascript" src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+    <meta charset="UTF-8"><style>/*
+     </style>
+    <link rel="stylesheet" href="css/animation.css"><!--[if IE 7]><link rel="stylesheet" href="css/" + font.fontname + "-ie7.css"><![endif]-->
+    <script>
+    </script>
+  </head>
+  <body>
+    <div class="container footer"></div>
+  </body>
+</html>

--- a/testdata/xml.withbr.xml
+++ b/testdata/xml.withbr.xml
@@ -1,0 +1,8 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Don't forget me this weekend!</body>
+</note>


### PR DESCRIPTION
Problem:
- HTML+XML files with whitespace before the opening tags were being identified as `text/plain`.

Solution:
- Trim whitespace from beginning using trimLWS (similar to geojson matcher)