### PR TITLE
DetectReader should read much

### DIFF
--- a/mimetype.go
+++ b/mimetype.go
@@ -36,8 +36,8 @@ func Detect(in []byte) (mime *MIME) {
 // matchers.ReadLimit bytes from the reader.
 func DetectReader(r io.Reader) (mime *MIME, err error) {
 	in := make([]byte, matchers.ReadLimit)
-	n, err := r.Read(in)
-	if err != nil && err != io.EOF {
+	n, err := io.ReadFull(r, in)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		return root, err
 	}
 	in = in[:n]


### PR DESCRIPTION
https://play.golang.org/p/cIGB9tHLPf1

```go
package main

import (
	"fmt"

	"github.com/gabriel-vasile/mimetype"
)

func main() {
	const src = "<html><head><title>html</title></head><body>abcdefg</body></html>"
	// breakReader breaks the string every breakSize characters.
	// It is like:
	//   <htm
	//   l><h
	//   ead>
	//   <tit
	//   le>h
	//   tml<
	//   ...
	r := breakReader(src)
	m, err := mimetype.DetectReader(&r)
	fmt.Println(m, err)
}

type breakReader string

func (s *breakReader) Read(p []byte) (int, error) {
	const breakSize = 4
	var t string
	n := min(breakSize, len(*s))
	*s, t = (*s)[n:], string((*s)[:n])
	copy(p, t)
	return n, nil
}

func min(x, y int) int {
	if x < y {
		return x
	}
	return y
}
```

Currently, DetectReader reads from a reader just once. As the above example shows, DetectReader may not be able to detect mime type.

