### PR TITLE
Add method to query mime type from internal database.

### DIFF
--- a/mimetype.go
+++ b/mimetype.go
@@ -62,3 +62,17 @@ func DetectFile(file string) (mime *MIME, err error) {
 
 	return DetectReader(f)
 }
+
+// Get a MIME type from the internal database.
+//
+// The result may be nil.
+//
+// The input is tested with MIME.Is() – aliases are considererd
+func GetMime(in string) (mime *MIME) {
+	for _, m := range root.flatten() {
+		if m.Is(in) {
+			return m
+		}
+	}
+	return nil
+}

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -334,3 +334,15 @@ func BenchmarkSlicePng(b *testing.B) {
 		mimetype.Detect(png)
 	}
 }
+
+func TestGetMime(t *testing.T) {
+	if mimetype.GetMime("text/plain; charset=utf-8").String() != "text/plain" {
+		t.Errorf("Query for text/plain; charset=utf-8 did not return text/plain.")
+	}
+	if mimetype.GetMime("text/plain").String() != "text/plain" {
+		t.Errorf("Query for text/plain did not return text/plain.")
+	}
+	if mimetype.GetMime("") != nil {
+		t.Errorf("Query for nonexistant mime type did not return nil.")
+	}
+}


### PR DESCRIPTION
I have a project which can download files, sometimes only given the mime type, not a file-name. Windows users would like me to give them a file name extension based on the mime type. I am already using this package, so it would be cool if I could look up a mime type by its string.