### PR TITLE
Check for EOF in DetectReader; closes #162

### DIFF
--- a/mimetype.go
+++ b/mimetype.go
@@ -50,7 +50,7 @@ func DetectReader(r io.Reader) (*MIME, error) {
 		n := 0
 		in = make([]byte, readLimit)
 		n, err = io.ReadFull(r, in)
-		if err != nil && err != io.ErrUnexpectedEOF {
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 			return root, err
 		}
 		in = in[:n]

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -385,6 +385,22 @@ func TestConcurrent(t *testing.T) {
 	mimetype.SetLimit(3072)
 }
 
+// For #162.
+func TestEmptyInput(t *testing.T) {
+	mtype, err := mimetype.DetectReader(bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("empty reader err; expected: nil, got: %s", err)
+	}
+	plain := "text/plain"
+	if !mtype.Is(plain) {
+		t.Fatalf("empty reader detection; expected: %s, got: %s", plain, mtype)
+	}
+	mtype = mimetype.Detect(nil)
+	if !mtype.Is(plain) {
+		t.Fatalf("empty bytes slice detection; expected: %s, got: %s", plain, mtype)
+	}
+}
+
 // Benchmarking a random slice of bytes is as close as possible to the real
 // world usage. A random byte slice is almost guaranteed to fail being detected.
 //


### PR DESCRIPTION
Before v1.2.0, DetectReader returned text/plain for empty inputs.
After v1.2.0, it started returning EOF error.
This commit changes DetectReader behavior to how it was before v1.2.0