### PR TITLE
Update added support for big excel files

### DIFF
--- a/internal/magic/ms_office.go
+++ b/internal/magic/ms_office.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"strings"
+	"sync/atomic"
 )
 
 var (
@@ -45,6 +46,10 @@ var (
 	}
 )
 
+// MaxMSOFileHeaders maximum number of local headers that are checked when
+// trying to identify a Microsoft Office file.
+var MaxMSOFileHeaders int32 = 10
+
 // zipTokenizer holds the source zip file and scanned index.
 type zipTokenizer struct {
 	in []byte
@@ -79,8 +84,11 @@ func (t *zipTokenizer) next() (fileName string) {
 // msoXML reads at most first 10 local headers and returns whether the input
 // looks like a Microsoft Office file.
 func msoXML(in []byte, prefixes ...string) bool {
+	// Using atomic because MaxMSOFileHeaders can be written at the same time in other goroutine.
+	maxTokensToCheck := int(atomic.LoadInt32(&MaxMSOFileHeaders))
+
 	t := zipTokenizer{in: in}
-	for i, tok := 0, t.next(); i < 10 && tok != ""; i, tok = i+1, t.next() {
+	for i, tok := 0, t.next(); i < maxTokensToCheck && tok != ""; i, tok = i+1, t.next() {
 		for p := range prefixes {
 			if strings.HasPrefix(tok, prefixes[p]) {
 				return true

--- a/internal/magic/ms_office.go
+++ b/internal/magic/ms_office.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"strings"
-	"sync/atomic"
 )
 
 var (
@@ -46,10 +45,6 @@ var (
 	}
 )
 
-// MaxMSOFileHeaders maximum number of local headers that are checked when
-// trying to identify a Microsoft Office file.
-var MaxMSOFileHeaders int32 = 10
-
 // zipTokenizer holds the source zip file and scanned index.
 type zipTokenizer struct {
 	in []byte
@@ -84,11 +79,8 @@ func (t *zipTokenizer) next() (fileName string) {
 // msoXML reads at most first 10 local headers and returns whether the input
 // looks like a Microsoft Office file.
 func msoXML(in []byte, prefixes ...string) bool {
-	// Using atomic because MaxMSOFileHeaders can be written at the same time in other goroutine.
-	maxTokensToCheck := int(atomic.LoadInt32(&MaxMSOFileHeaders))
-
 	t := zipTokenizer{in: in}
-	for i, tok := 0, t.next(); i < maxTokensToCheck && tok != ""; i, tok = i+1, t.next() {
+	for i, tok := 0, t.next(); tok != ""; i, tok = i+1, t.next() {
 		for p := range prefixes {
 			if strings.HasPrefix(tok, prefixes[p]) {
 				return true

--- a/mimetype.go
+++ b/mimetype.go
@@ -11,8 +11,6 @@ import (
 	"mime"
 	"os"
 	"sync/atomic"
-
-	"github.com/gabriel-vasile/mimetype/internal/magic"
 )
 
 // readLimit is the maximum number of bytes from the input used when detecting.
@@ -108,13 +106,6 @@ func EqualsAny(s string, mimes ...string) bool {
 func SetLimit(limit uint32) {
 	// Using atomic because readLimit can be read at the same time in other goroutine.
 	atomic.StoreUint32(&readLimit, limit)
-}
-
-// SetMaxMSOFileHeaders sets the maximum number of local headers that are checked when
-// trying to identify a Microsoft Office file.
-func SetMaxMSOFileHeaders(max int32) {
-	// Using atomic because MaxMSOFileHeaders can be written at the same time in other goroutine.
-	atomic.StoreInt32(&magic.MaxMSOFileHeaders, max)
 }
 
 // Extend adds detection for other file formats.

--- a/mimetype.go
+++ b/mimetype.go
@@ -11,6 +11,8 @@ import (
 	"mime"
 	"os"
 	"sync/atomic"
+
+	"github.com/gabriel-vasile/mimetype/internal/magic"
 )
 
 // readLimit is the maximum number of bytes from the input used when detecting.
@@ -106,6 +108,13 @@ func EqualsAny(s string, mimes ...string) bool {
 func SetLimit(limit uint32) {
 	// Using atomic because readLimit can be read at the same time in other goroutine.
 	atomic.StoreUint32(&readLimit, limit)
+}
+
+// SetMaxMSOFileHeaders sets the maximum number of local headers that are checked when
+// trying to identify a Microsoft Office file.
+func SetMaxMSOFileHeaders(max int32) {
+	// Using atomic because MaxMSOFileHeaders can be written at the same time in other goroutine.
+	atomic.StoreInt32(&magic.MaxMSOFileHeaders, max)
 }
 
 // Extend adds detection for other file formats.


### PR DESCRIPTION
# Adds support for big excel files
By adding the possibility to configure the amount of local headers checked

There the problem can be (depending on the library generating the file) that the headers are more than 10 and the relevant ones for identifying it as an excel file are at place 11 or above.

## Reason for the Change
We have some bigger excel documents (which I can't share due to compliance restrictions) that aren't detected correctly.
After analyzing the problem it turned out that it is not enough for those kind of documents to check only the first 10 local headers.

## How we use it with that change
```
// increase the read limit (default is 3072) and the amount of MSO file headers checked to support big excel files as well
mimetype.SetLimit(20480)
mimetype.SetMaxMSOFileHeaders(100)
detectedMimeType := mimetype.Detect(data)
```
