### PR TITLE
Fix detection for CFB files version 4

### DIFF
--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -125,6 +125,7 @@ var files = map[string]string{
 	"mpeg.mpeg":          "video/mpeg",
 	"mqv.mqv":            "video/quicktime",
 	"mrc.mrc":            "application/marc",
+	"msi.msi":            "application/x-ms-installer",
 	"msg.msg":            "application/vnd.ms-outlook",
 	"ndjson.xl.ndjson":   "application/x-ndjson",
 	"ndjson.ndjson":      "application/x-ndjson",


### PR DESCRIPTION
Previously the offset for the CLSID was searched for using v3 offsets.
This commit changes detection to check CFB version in order 
choose between v3(512) and v4(4096) 
https://www.loc.gov/preservation/digital/formats/fdd/fdd000392.shtml