### PR TITLE
Fix json detected as dbf when it starts with low ascii values

### DIFF
--- a/internal/magic/binary.go
+++ b/internal/magic/binary.go
@@ -64,16 +64,27 @@ func MachO(raw []byte, limit uint32) bool {
 // Dbf matches a dBase file.
 // https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
 func Dbf(raw []byte, limit uint32) bool {
-	if len(raw) < 4 {
+	if len(raw) < 68 {
 		return false
 	}
 
-	// 3rd and 4th bytes contain the last update month and day of month
+	// 3rd and 4th bytes contain the last update month and day of month.
 	if !(0 < raw[2] && raw[2] < 13 && 0 < raw[3] && raw[3] < 32) {
 		return false
 	}
 
-	// dbf type is dictated by the first byte
+	// 12, 13, 30, 31 are reserved bytes and always filled with 0x00.
+	if raw[12] != 0x00 || raw[13] != 0x00 || raw[30] != 0x00 || raw[31] != 0x00 {
+		return false
+	}
+	// Production MDX flag;
+	// 0x01 if a production .MDX file exists for this table;
+	// 0x00 if no .MDX file exists.
+	if raw[28] > 0x01 {
+		return false
+	}
+
+	// dbf type is dictated by the first byte.
 	dbfTypes := []byte{
 		0x02, 0x03, 0x04, 0x05, 0x30, 0x31, 0x32, 0x42, 0x62, 0x7B, 0x82,
 		0x83, 0x87, 0x8A, 0x8B, 0x8E, 0xB3, 0xCB, 0xE5, 0xF5, 0xF4, 0xFB,

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -94,6 +94,7 @@ var files = map[string]string{
 	"xpm.xpm":            "image/x-xpixmap",
 	"js.js":              "application/javascript",
 	"json.json":          "application/json",
+	"json.lowascii.json": "application/json",
 	// json.{int,float,string}.txt contain a single JSON value. They are valid JSON
 	// documents, but they should not be detected as application/json. This mimics
 	// the behaviour of the file utility and seems the correct thing to do.

--- a/testdata/json.lowascii.json
+++ b/testdata/json.lowascii.json
@@ -1,0 +1,2 @@
+{
+		"fixture for issue #": 239}


### PR DESCRIPTION
Byte 0x09 represents ninth month in dbf header, but it is also the ascii
value of < TAB >. This made dbf detection pass for json and txt files
happening to contain low ascii values at the start.
This commit improves dbf detection to check for several null bytes in
the input. json and txt files never contain null bytes.