### PR TITLE
Add `application/x-subrip` alias for Srt

### DIFF
--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -172,7 +172,7 @@ var files = map[string]string{
 	"shx.shx":            "application/octet-stream",
 	"so.so":              "application/x-sharedlib",
 	"sqlite.sqlite":      "application/vnd.sqlite3",
-	"srt.srt":            "text/x-subrip",
+	"srt.srt":            "application/x-subrip",
 	// not.srt.txt uses periods instead of commas for the decimal separators of
 	// the timestamps.
 	"not.srt.txt": "text/plain; charset=utf-8",

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -163,7 +163,7 @@ Extension | MIME type | Aliases
 **.har** | application/json | -
 **.ndjson** | application/x-ndjson | -
 **.rtf** | text/rtf | -
-**.srt** | application/x-subrip | text/x-srt, text/x-subrip
+**.srt** | application/x-subrip | application/x-srt, text/x-srt
 **.tcl** | text/x-tcl | application/x-tcl
 **.csv** | text/csv | -
 **.tsv** | text/tab-separated-values | -

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -163,7 +163,7 @@ Extension | MIME type | Aliases
 **.har** | application/json | -
 **.ndjson** | application/x-ndjson | -
 **.rtf** | text/rtf | -
-**.srt** | text/x-subrip | text/x-srt, application/x-subrip
+**.srt** | application/x-subrip | text/x-srt, text/x-subrip
 **.tcl** | text/x-tcl | application/x-tcl
 **.csv** | text/csv | -
 **.tsv** | text/tab-separated-values | -

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -163,7 +163,7 @@ Extension | MIME type | Aliases
 **.har** | application/json | -
 **.ndjson** | application/x-ndjson | -
 **.rtf** | text/rtf | -
-**.srt** | text/x-subrip | text/x-srt
+**.srt** | text/x-subrip | text/x-srt, application/x-subrip
 **.tcl** | text/x-tcl | application/x-tcl
 **.csv** | text/csv | -
 **.tsv** | text/tab-separated-values | -

--- a/tree.go
+++ b/tree.go
@@ -90,7 +90,7 @@ var (
 	js       = newMIME("application/javascript", ".js", magic.Js).
 			alias("application/x-javascript", "text/javascript")
 	srt = newMIME("text/x-subrip", ".srt", magic.Srt).
-		alias("text/x-srt")
+		alias("text/x-srt", "application/x-subrip")
 	vtt    = newMIME("text/vtt", ".vtt", magic.Vtt)
 	lua    = newMIME("text/x-lua", ".lua", magic.Lua)
 	perl   = newMIME("text/x-perl", ".pl", magic.Perl)

--- a/tree.go
+++ b/tree.go
@@ -89,8 +89,8 @@ var (
 	rtf      = newMIME("text/rtf", ".rtf", magic.Rtf)
 	js       = newMIME("application/javascript", ".js", magic.Js).
 			alias("application/x-javascript", "text/javascript")
-	srt = newMIME("text/x-subrip", ".srt", magic.Srt).
-		alias("text/x-srt", "application/x-subrip")
+	srt = newMIME("application/x-subrip", ".srt", magic.Srt).
+		alias("text/x-srt", "text/x-subrip")
 	vtt    = newMIME("text/vtt", ".vtt", magic.Vtt)
 	lua    = newMIME("text/x-lua", ".lua", magic.Lua)
 	perl   = newMIME("text/x-perl", ".pl", magic.Perl)

--- a/tree.go
+++ b/tree.go
@@ -90,7 +90,7 @@ var (
 	js       = newMIME("application/javascript", ".js", magic.Js).
 			alias("application/x-javascript", "text/javascript")
 	srt = newMIME("application/x-subrip", ".srt", magic.Srt).
-		alias("text/x-srt", "text/x-subrip")
+		alias("application/x-srt", "text/x-srt")
 	vtt    = newMIME("text/vtt", ".vtt", magic.Vtt)
 	lua    = newMIME("text/x-lua", ".lua", magic.Lua)
 	perl   = newMIME("text/x-perl", ".pl", magic.Perl)


### PR DESCRIPTION
Sorry to bother again. Would it be OK to add `application/x-subrip` alias for the SubRip format? My own motivation is [this](https://github.com/Podcastindex-org/podcast-namespace/commit/91b3e5eee40b03559b9bd04032a5fb019b78ec00), and a quick search reveals it is used in many places, including the [Android reference](https://developer.android.com/reference/android/media/MediaFormat#MIMETYPE_TEXT_SUBRIP).