### PR TITLE
Move from coveralls to codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,20 +47,14 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3.0.1
     - name: Install Go
       if: success()
       uses: actions/setup-go@v2.2.0
       with:
-        go-version: 1.16
-    - name: Checkout code
-      uses: actions/checkout@v3.0.1
-    - name: Calc coverage
-      run: |
-        go test -v -covermode=count -coverprofile=coverage.out
-    - name: Convert coverage.out to coverage.lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.8
-    - name: Coveralls
-      uses: coverallsapp/github-action@1.1.3
+        go-version: "1.18.x"
+    - name: Generate coverage
+      run: go test -race -covermode=atomic -coverprofile=coverage.out
+    - uses: codecov/codecov-action@v3.1.0
       with:
-          github-token: ${{ secrets.github_token }}
-          path-to-lcov: coverage.lcov
+        files: ./coverage.out

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
     <img alt="Build Status" src="https://travis-ci.org/gabriel-vasile/mimetype.svg?branch=master">
   </a>
   <a href="https://pkg.go.dev/github.com/gabriel-vasile/mimetype">
-    <img src="https://pkg.go.dev/badge/github.com/gabriel-vasile/mimetype.svg" alt="Go Reference">
+    <img alt="Go Reference" src="https://pkg.go.dev/badge/github.com/gabriel-vasile/mimetype.svg">
   </a>
   <a href="https://goreportcard.com/report/github.com/gabriel-vasile/mimetype">
     <img alt="Go report card" src="https://goreportcard.com/badge/github.com/gabriel-vasile/mimetype">
   </a>
-  <a href="https://coveralls.io/github/gabriel-vasile/mimetype?branch=master">
-    <img alt="Go report card" src="https://coveralls.io/repos/github/gabriel-vasile/mimetype/badge.svg?branch=master">
+  <a href="https://codecov.io/gh/gabriel-vasile/mimetype">
+    <img alt="Code coverage" src="https://codecov.io/gh/gabriel-vasile/mimetype/branch/master/graph/badge.svg?token=qcfJF1kkl2"/>
   </a>
   <a href="LICENSE">
     <img alt="License" src="https://img.shields.io/badge/License-MIT-green.svg">


### PR DESCRIPTION
Coveralls requires GITHUB_TOKEN inside Actions yaml. This is a security
issue because PRs can extract that secret. Codecov does not require the
token.