### PR TITLE
Change python main type from application to text

### DIFF
--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -161,7 +161,7 @@ var files = map[string]string{
 	"p7s_pem.p7s":        "application/pkcs7-signature",
 	"p7s_der.p7s":        "application/pkcs7-signature",
 	"pub.pub":            "application/vnd.ms-publisher",
-	"py.py":              "application/x-python",
+	"py.py":              "text/x-python",
 	"qcp.qcp":            "audio/qcelp",
 	"rar.rar":            "application/x-rar-compressed",
 	"rmvb.rmvb":          "application/vnd.rn-realmedia-vbr",

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -160,7 +160,7 @@ Extension | MIME type | Aliases
 **.js** | application/javascript | application/x-javascript, text/javascript
 **.lua** | text/x-lua | -
 **.pl** | text/x-perl | -
-**.py** | application/x-python | -
+**.py** | text/x-python | text/x-script.python, application/x-python
 **.json** | application/json | -
 **.geojson** | application/geo+json | -
 **.har** | application/json | -

--- a/tree.go
+++ b/tree.go
@@ -94,8 +94,9 @@ var (
 	vtt    = newMIME("text/vtt", ".vtt", magic.Vtt)
 	lua    = newMIME("text/x-lua", ".lua", magic.Lua)
 	perl   = newMIME("text/x-perl", ".pl", magic.Perl)
-	python = newMIME("application/x-python", ".py", magic.Python)
-	tcl    = newMIME("text/x-tcl", ".tcl", magic.Tcl).
+	python = newMIME("text/x-python", ".py", magic.Python).
+		alias("text/x-script.python", "application/x-python")
+	tcl = newMIME("text/x-tcl", ".tcl", magic.Tcl).
 		alias("application/x-tcl")
 	vCard     = newMIME("text/vcard", ".vcf", magic.VCard)
 	iCalendar = newMIME("text/calendar", ".ics", magic.ICalendar)


### PR DESCRIPTION
Rename python scripts from application/x-python to text/x-python.
Add aliases for text/x-script.python and application/x-python. For #284