### PR TITLE
Added support for PDF files started with 0xA

### DIFF
--- a/internal/magic/document.go
+++ b/internal/magic/document.go
@@ -4,9 +4,9 @@ import "bytes"
 
 var (
 	// Pdf matches a Portable Document Format file.
-	Pdf = prefix([]byte{0x25, 0x50, 0x44, 0x46})
+	Pdf = prefix([]byte("%PDF-"), []byte("\x0A%PDF-"))
 	// Fdf matches a Forms Data Format file.
-	Fdf = prefix([]byte("%FDF"))
+	Fdf = prefix([]byte("%FDF-"))
 	// Mobi matches a Mobi file.
 	Mobi = offset([]byte("BOOKMOBI"), 60)
 	// Lit matches a Microsoft Lit file.


### PR DESCRIPTION
Fixes #285.

I added a PDF signature with 0x0A at start and extended PDF and FDF signatures with minus sign just like in Darwin's and OpenBSD's file utilities.