### PR TITLE
enable reusing records in csv/tsv detection

### DIFF
--- a/internal/magic/text_csv.go
+++ b/internal/magic/text_csv.go
@@ -20,7 +20,7 @@ func Tsv(raw []byte, limit uint32) bool {
 func sv(in []byte, comma rune, limit uint32) bool {
 	r := csv.NewReader(dropLastLine(in, limit))
 	r.Comma = comma
-	r.TrimLeadingSpace = true
+	r.ReuseRecord = true
 	r.LazyQuotes = true
 	r.Comment = '#'
 


### PR DESCRIPTION
This change should help with allocations, but ideally there would be no allocations when detecting csv. For that to happen the detection needs to move from using stdlib csv reader to something else.