### PR TITLE
Update LICENSE: remove ending year in copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Gabriel Vasile
+Copyright (c) 2018 Gabriel Vasile
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
There is no need for ending year in license