### PR TITLE
ftyp: exit asap to prevent mem allocs

### DIFF
--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -153,8 +153,11 @@ func ftyp(sigs ...[]byte) Detector {
 		if len(raw) < 12 {
 			return false
 		}
+		if !bytes.Equal(raw[4:8], []byte("ftyp")) {
+			return false
+		}
 		for _, s := range sigs {
-			if bytes.Equal(raw[4:12], append([]byte("ftyp"), s...)) {
+			if bytes.Equal(raw[8:12], s) {
 				return true
 			}
 		}


### PR DESCRIPTION
`go test -bench=SliceRand -benchmem`
before:
`BenchmarkSliceRand-8   	  688160	      1690 ns/op	     728 B/op	      75 allocs/op`
after:
`BenchmarkSliceRand-8   	 1232066	      1173 ns/op	     160 B/op	       4 allocs/op`