### PR TITLE
tar: remove strconv dependency for tar checksum octal numbers

### DIFF
--- a/internal/magic/archive_test.go
+++ b/internal/magic/archive_test.go
@@ -6,32 +6,23 @@ func TestTarParseOctal(t *testing.T) {
 	tests := []struct {
 		in   string
 		want int64
-		ok   bool
 	}{
-		{"0000000\x00", 0, true},
-		{" \x0000000\x00", 0, true},
-		{" \x0000003\x00", 3, true},
-		{"00000000227\x00", 0227, true},
-		{"032033\x00 ", 032033, true},
-		{"320330\x00 ", 0320330, true},
-		{"0000660\x00 ", 0660, true},
-		{"\x00 0000660\x00 ", 0660, true},
-		{"0123456789abcdef", 0, false},
-		{"0123456789\x00abcdef", 0, false},
-		{"01234567\x0089abcdef", 342391, true},
-		{"0123\x7e\x5f\x264123", 0, false},
+		{"0000000\x00", 0},
+		{" \x0000000\x00", 0},
+		{" \x0000003\x00", 3},
+		{"00000000227\x00", 0227},
+		{"032033\x00 ", 032033},
+		{"320330\x00 ", 0320330},
+		{"0000660\x00 ", 0660},
+		{"\x00 0000660\x00 ", 0660},
+		{"0123456789abcdef", -1},
+		{"0123456789\x00abcdef", -1},
+		{"01234567\x0089abcdef", 01234567},
+		{"0123\x7e\x5f\x264123", -1},
 	}
 
 	for _, tt := range tests {
-		got, err := tarParseOctal([]byte(tt.in))
-		ok := err == nil
-		if ok != tt.ok {
-			if tt.ok {
-				t.Errorf("parseOctal(%q): got parsing failure, want success", tt.in)
-			} else {
-				t.Errorf("parseOctal(%q): got parsing success, want failure", tt.in)
-			}
-		}
+		got := tarParseOctal([]byte(tt.in))
 		if got != tt.want {
 			t.Errorf("parseOctal(%q): got %d, want %d", tt.in, got, tt.want)
 		}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/gabriel-vasile/mimetype
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
               │ common_master │              common_dev              │
               │    sec/op     │    sec/op     vs base                │
Common/.xlsx-8    401.2n ±  3%   312.2n ±  5%  -22.17% (p=0.000 n=10)
Common/.pptx-8    1.708µ ±  4%   1.535µ ±  3%  -10.10% (p=0.000 n=10)
Common/.docx-8    1.260µ ±  7%   1.116µ ±  4%  -11.43% (p=0.000 n=10)
Common/.tar-8    1011.0n ±  7%   785.0n ±  4%  -22.35% (p=0.000 n=10)
Common/.zip-8     742.3n ± 11%   616.2n ± 16%  -16.99% (p=0.003 n=10)
Common/.pdf-8     291.6n ±  4%   191.9n ±  4%  -34.20% (p=0.000 n=10)
Common/.jpg-8     410.7n ±  9%   374.1n ± 17%   -8.90% (p=0.019 n=10)
Common/.png-8     425.1n ±  8%   327.8n ±  8%  -22.89% (p=0.000 n=10)
Common/.gif-8     480.4n ±  4%   396.9n ±  7%  -17.38% (p=0.000 n=10)
Common/.xls-8     427.2n ±  6%   324.7n ±  4%  -24.00% (p=0.000 n=10)
Common/.webm-8   1160.0n ±  5%   724.8n ±  5%  -37.52% (p=0.000 n=10)
Common/.csv-8     6.965µ ±  7%   5.671µ ±  6%  -18.57% (p=0.000 n=10)
geomean           784.9n         620.0n        -21.01%

               │ common_master │              common_dev               │
               │     B/op      │     B/op      vs base                 │
Common/.xlsx-8      312.0 ± 0%     312.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.pptx-8      592.0 ± 0%     592.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.docx-8      504.0 ± 0%     504.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.tar-8       200.0 ± 0%     192.0 ± 0%  -4.00% (p=0.000 n=10)
Common/.zip-8       224.0 ± 0%     224.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.pdf-8       192.0 ± 0%     192.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.jpg-8       192.0 ± 0%     192.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.png-8       192.0 ± 0%     192.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.gif-8       192.0 ± 0%     192.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.xls-8       288.0 ± 0%     288.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.webm-8      192.0 ± 0%     192.0 ± 0%       ~ (p=1.000 n=10) ¹
Common/.csv-8     7.390Ki ± 0%   7.323Ki ± 0%  -0.90% (p=0.000 n=10)
geomean             339.8          338.4       -0.41%
¹ all samples are equal

               │ common_master │              common_dev              │
               │   allocs/op   │ allocs/op   vs base                  │
Common/.xlsx-8      4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.pptx-8      15.00 ± 0%   15.00 ± 0%        ~ (p=1.000 n=10) ¹
Common/.docx-8      13.00 ± 0%   13.00 ± 0%        ~ (p=1.000 n=10) ¹
Common/.tar-8       3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
Common/.zip-8       6.000 ± 0%   6.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.pdf-8       2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.jpg-8       2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.png-8       2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.gif-8       2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.xls-8       3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.webm-8      2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
Common/.csv-8       34.00 ± 0%   31.00 ± 0%   -8.82% (p=0.000 n=10)
geomean             4.349        4.173        -4.06%
¹ all samples are equal

            │ rand_master │              rand_dev               │
            │   sec/op    │   sec/op     vs base                │
SliceRand-8   457.4n ± 4%   398.1n ± 3%  -12.96% (p=0.000 n=10)

            │ rand_master │              rand_dev              │
            │    B/op     │    B/op     vs base                │
SliceRand-8   160.00 ± 0%   96.00 ± 0%  -40.00% (p=0.000 n=10)

            │ rand_master │              rand_dev              │
            │  allocs/op  │ allocs/op   vs base                │
SliceRand-8    4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.000 n=10)
```