### PR TITLE
Updating RTF Magic number to match https://www.iana.org/assignments/media-types/application/rtf

### DIFF
--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -120,7 +120,7 @@ var (
 		[]byte("/usr/bin/env wish"),
 	)
 	// Rtf matches a Rich Text Format file.
-	Rtf = prefix([]byte("{\\rtf1"))
+	Rtf = prefix([]byte("{\\rtf"))
 )
 
 // Text matches a plain text file.


### PR DESCRIPTION
Updating RTF Magic number to match the following references:
- <https://www.iana.org/assignments/media-types/application/rtf>
- <https://github.com/file/file/blob/99d21e9f799e415ea8f616b9de093b4e9a1bae56/magic/Magdir/rtf#L11C1-L11C10>
- <https://www.loc.gov/preservation/digital/formats/fdd/fdd000473.shtml>

It appears as though the version number is not required in a Rich Text Format header to create a readable rtf file.

However, these magic numbers seem to diverge from the official specification from Microsoft, that indicate a version number is required:
> An entire RTF file is considered a group and must be enclosed in braces. The control word `\rtf<N>` must follow the opening brace. The numeric parameter `<N>` identifies the version of the RTF standard used. The RTF standard described in this RTF Specification, although titled as version `1.{0, 1, 2, 3, 4, 5, 6, 7, 8, 9.1}`, continues to correspond syntactically to RTF Specification version 1. Therefore, the numeric parameter `<N>` for the `\rtf` control word should still be emitted as 1.
sources: 
- <https://msopenspecs.azureedge.net/files/Archive_References/[MSFT-RTF].pdf>
- <https://latex2rtf.sourceforge.net/rtfspec_6.html#rtfspec_7>

This PR increases the detection of Rich Text Format files that do not include a version number

