### PR TITLE
alias text/rtf to application/rtf

### DIFF
--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -167,7 +167,7 @@ Extension | MIME type | Aliases
 **.geojson** | application/geo+json | -
 **.har** | application/json | -
 **.ndjson** | application/x-ndjson | -
-**.rtf** | text/rtf | -
+**.rtf** | text/rtf | application/rtf
 **.srt** | application/x-subrip | application/x-srt, text/x-srt
 **.tcl** | text/x-tcl | application/x-tcl
 **.csv** | text/csv | -

--- a/tree.go
+++ b/tree.go
@@ -86,7 +86,7 @@ var (
 	ndJSON   = newMIME("application/x-ndjson", ".ndjson", magic.NdJSON)
 	html     = newMIME("text/html", ".html", magic.HTML)
 	php      = newMIME("text/x-php", ".php", magic.Php)
-	rtf      = newMIME("text/rtf", ".rtf", magic.Rtf)
+	rtf      = newMIME("text/rtf", ".rtf", magic.Rtf).alias("application/rtf")
 	js       = newMIME("application/javascript", ".js", magic.Js).
 			alias("application/x-javascript", "text/javascript")
 	srt = newMIME("application/x-subrip", ".srt", magic.Srt).


### PR DESCRIPTION
Seems like rtf uses both `text/rtf` and `application/rtf` and we only have the first.

Discovered the issue while reviewing #544.