### PR TITLE
CSV/TSV use a pool of buffered readers to avoid allocs

### DIFF
--- a/internal/magic/text_csv_test.go
+++ b/internal/magic/text_csv_test.go
@@ -1,0 +1,20 @@
+package magic
+
+import (
+	"io"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkCsv(b *testing.B) {
+	r := rand.New(rand.NewSource(0))
+	data := make([]byte, 4096)
+	if _, err := io.ReadFull(r, data); err != io.ErrUnexpectedEOF && err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Csv(data, 0)
+	}
+}


### PR DESCRIPTION
use a pool of buffers to alleviate memory allocs in csv; related to #553


When iterating over multiple files, csv detector allocated a new buffer
for each file. This change adds a pool of buffers that can be reused
between detections. The same pool is shared between csv and tsv
detectors.

Benchmark results:
```bash
➜  magic git:(csvpprof) ✗ benchstat before after
goos: linux
goarch: amd64
pkg: github.com/gabriel-vasile/mimetype/internal/magic
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
      │   before    │               after                │
      │   sec/op    │   sec/op     vs base               │
Csv-8   3.052µ ± 3%   1.695µ ± 3%  -44.46% (p=0.001 n=7)

      │    before    │                after                │
      │     B/op     │     B/op      vs base               │
Csv-8   5.258Ki ± 0%   1.164Ki ± 0%  -77.86% (p=0.001 n=7)

      │   before   │               after               │
      │ allocs/op  │ allocs/op   vs base               │
Csv-8   13.00 ± 0%   11.00 ± 0%  -15.38% (p=0.001 n=7)
```