### PR TITLE
rename application/javascript to text/javascript

### DIFF
--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -138,7 +138,7 @@ var testcases = []testcase{
 	{"jxl 2", "\x00\x00\x00\x0cJXL\x20\x0d\x0a\x87\x0a", "image/jxl", false},
 	{"jxr", "\x49\x49\xBC\x01", "image/jxr", true},
 	{"xpm", "\x2F\x2A\x20\x58\x50\x4D\x20\x2A\x2F", "image/x-xpixmap", true},
-	{"js", "#!/bin/node ", "application/javascript", true},
+	{"js", "#!/bin/node ", "text/javascript", true},
 	{"json", `{"key":"val"}`, "application/json", true},
 	{"json issue#239", "{\x0A\x09\x09\"key\":\"val\"}\x0A", "application/json", false},
 	// json.{int,string}.txt contain a single JSON value. They are valid JSON

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -163,7 +163,7 @@ Extension | MIME type | Aliases
 **.xfdf** | application/vnd.adobe.xfdf | -
 **.owl** | application/owl+xml | -
 **.php** | text/x-php | -
-**.js** | application/javascript | application/x-javascript, text/javascript
+**.js** | text/javascript | application/x-javascript, application/javascript
 **.lua** | text/x-lua | -
 **.pl** | text/x-perl | -
 **.py** | text/x-python | text/x-script.python, application/x-python

--- a/tree.go
+++ b/tree.go
@@ -87,8 +87,8 @@ var (
 	html    = newMIME("text/html", ".html", magic.HTML)
 	php     = newMIME("text/x-php", ".php", magic.Php)
 	rtf     = newMIME("text/rtf", ".rtf", magic.Rtf).alias("application/rtf")
-	js      = newMIME("application/javascript", ".js", magic.Js).
-		alias("application/x-javascript", "text/javascript")
+	js      = newMIME("text/javascript", ".js", magic.Js).
+		alias("application/x-javascript", "application/javascript")
 	srt = newMIME("application/x-subrip", ".srt", magic.Srt).
 		alias("application/x-srt", "text/x-srt")
 	vtt    = newMIME("text/vtt", ".vtt", magic.Vtt)


### PR DESCRIPTION
In accordance with latest IANA specification and with what go sdtlib is doing.
https://www.iana.org/assignments/media-types/text/javascript
Close #90.