### PR TITLE
zstd: check for skippable frames as well; fix #619

### DIFF
--- a/internal/magic/archive.go
+++ b/internal/magic/archive.go
@@ -52,10 +52,15 @@ func InstallShieldCab(raw []byte, _ uint32) bool {
 }
 
 // Zstd matches a Zstandard archive file.
+// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md
 func Zstd(raw []byte, limit uint32) bool {
-	return len(raw) >= 4 &&
-		(0x22 <= raw[0] && raw[0] <= 0x28 || raw[0] == 0x1E) && // Different Zstandard versions.
-		bytes.HasPrefix(raw[1:], []byte{0xB5, 0x2F, 0xFD})
+	if len(raw) < 4 {
+		return false
+	}
+	sig := binary.LittleEndian.Uint32(raw)
+	// Check for Zstandard frames and skippable frames.
+	return (sig >= 0xFD2FB522 && sig <= 0xFD2FB528) ||
+		(sig >= 0x184D2A50 && sig <= 0x184D2A5F)
 }
 
 // CRX matches a Chrome extension file: a zip archive prepended by a package header.

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -262,6 +262,7 @@ var testcases = []testcase{
 	{"xz", "\xfd7zXZ\x00", "application/x-xz", true},
 	{"zip", "PK\x03\x04", "application/zip", true},
 	{"zst", "(\xb5/\xfd", "application/zstd", true},
+	{"zst skippable frame", "\x50\x2A\x4D\x18", "application/zstd", false},
 }
 
 func TestDetect(t *testing.T) {


### PR DESCRIPTION
Previous detection was not working for skippable frames: https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#skippable-frames