### PR TITLE
(cve_fix)bump golang.org/x/net to v0.33.0 to fix CVE-2024-45338

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gabriel-vasile/mimetype
 
 go 1.20
 
-require golang.org/x/net v0.31.0
+require golang.org/x/net v0.33.0
 
 // v1.4.4 had a test file detected as malicious by antivirus software. #575
 retract v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
-golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=


### PR DESCRIPTION
Bumping golang.org/x/net to v0.33.0 to fix CVE-2024-45338

**Report from snyk on the current version:**
  High severity vulnerability found in golang.org/x/net/html
  Description: Denial of Service (DoS)
  Info: https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTML-8535262
  Introduced through: golang.org/x/net/html@0.31.0
  From: golang.org/x/net/html@0.31.0
  Fixed in: 0.33.0