### PR TITLE
json: skip tracking json path if not needed

### DIFF
--- a/internal/json/parser.go
+++ b/internal/json/parser.go
@@ -258,7 +258,7 @@ out:
 }
 
 func (p *parserState) consumeArray(b []byte, qs []query, lvl int) (n int) {
-	p.currPath = append(p.currPath, []byte{'['})
+	p.appendPath([]byte{'['}, qs)
 	if len(b) == 0 {
 		return 0
 	}
@@ -270,7 +270,7 @@ func (p *parserState) consumeArray(b []byte, qs []query, lvl int) (n int) {
 		}
 		if b[n] == ']' {
 			p.ib++
-			p.currPath = p.currPath[:len(p.currPath)-1]
+			p.popLastPath(qs)
 			return n + 1
 		}
 		innerParsed := p.consumeAny(b[n:], qs, lvl)
@@ -305,6 +305,20 @@ func queryPathMatch(qs []query, path [][]byte) int {
 	return -1
 }
 
+// appendPath will append a path fragment if queries is not empty.
+// If we don't need query functionality (just checking if a JSON is valid),
+// then we can skip keeping track of the path we're currently in.
+func (p *parserState) appendPath(path []byte, qs []query) {
+	if len(qs) != 0 {
+		p.currPath = append(p.currPath, path)
+	}
+}
+func (p *parserState) popLastPath(qs []query) {
+	if len(qs) != 0 {
+		p.currPath = p.currPath[:len(p.currPath)-1]
+	}
+}
+
 func (p *parserState) consumeObject(b []byte, qs []query, lvl int) (n int) {
 	for n < len(b) {
 		n += p.consumeSpace(b[n:])
@@ -326,7 +340,7 @@ func (p *parserState) consumeObject(b []byte, qs []query, lvl int) (n int) {
 		if keyLen := p.consumeString(b[n:]); keyLen == 0 {
 			return 0
 		} else {
-			p.currPath = append(p.currPath, b[n:n+keyLen-1])
+			p.appendPath(b[n:n+keyLen-1], qs)
 			if !p.querySatisfied {
 				queryMatched = queryPathMatch(qs, p.currPath)
 			}
@@ -368,12 +382,12 @@ func (p *parserState) consumeObject(b []byte, qs []query, lvl int) (n int) {
 		}
 		switch b[n] {
 		case ',':
-			p.currPath = p.currPath[:len(p.currPath)-1]
+			p.popLastPath(qs)
 			n++
 			p.ib++
 			continue
 		case '}':
-			p.currPath = p.currPath[:len(p.currPath)-1]
+			p.popLastPath(qs)
 			p.ib++
 			return n + 1
 		default:
@@ -387,6 +401,9 @@ func (p *parserState) consumeAny(b []byte, qs []query, lvl int) (n int) {
 	// Avoid too much recursion.
 	if p.maxRecursion != 0 && lvl > p.maxRecursion {
 		return 0
+	}
+	if len(qs) == 0 {
+		p.querySatisfied = true
 	}
 	n += p.consumeSpace(b)
 	if len(b[n:]) == 0 {
@@ -425,9 +442,6 @@ func (p *parserState) consumeAny(b []byte, qs []query, lvl int) (n int) {
 	}
 	if lvl == 0 {
 		p.firstToken = t
-	}
-	if len(qs) == 0 {
-		p.querySatisfied = true
 	}
 	if rv <= 0 {
 		return n

--- a/internal/json/parser_test.go
+++ b/internal/json/parser_test.go
@@ -746,7 +746,7 @@ func TestStack(t *testing.T) {
 	for _, tt := range tCases {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &parserState{}
-			p.consumeAny([]byte(tt.data), nil, 0)
+			p.consumeAny([]byte(tt.data), []query{{}}, 0)
 			if got := join(p.currPath); got != tt.expected {
 				t.Errorf("expected: %s, got: %s", tt.expected, got)
 			}


### PR DESCRIPTION
When just testing if JSON syntax is ok (not checking any json fields exist) we don't need to keep track of current path inside the json. Allocs are reduced as consequence of this commit.