### PR TITLE
scan.Bytes: a single package for dealing with bytes

### DIFF
--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -146,7 +146,7 @@ func fromXML(s scan.Bytes) string {
 		if len(s) == 0 {
 			return ""
 		}
-		for isWS(s.Peek()) {
+		for scan.ByteIsWS(s.Peek()) {
 			s.Advance(1)
 		}
 		if len(s) <= lxml {
@@ -227,7 +227,7 @@ func fromHTML(s scan.Bytes) string {
 		}
 		s.Advance(lmeta)
 		c := s.Pop()
-		if c == 0 || (!isWS(c) && c != '/') {
+		if c == 0 || (!scan.ByteIsWS(c) && c != '/') {
 			return ""
 		}
 		attrList := make(map[string]bool)
@@ -280,13 +280,13 @@ func extractCharsetFromMeta(s scan.Bytes) []byte {
 			return nil
 		}
 		s.Advance(i + len("charset"))
-		for isWS(s.Peek()) {
+		for scan.ByteIsWS(s.Peek()) {
 			s.Advance(1)
 		}
 		if s.Pop() != '=' {
 			continue
 		}
-		for isWS(s.Peek()) {
+		for scan.ByteIsWS(s.Peek()) {
 			s.Advance(1)
 		}
 		quote := s.Peek()
@@ -303,7 +303,7 @@ func extractCharsetFromMeta(s scan.Bytes) []byte {
 }
 
 func getAnAttribute(s *scan.Bytes) (name, val string, hasMore bool) {
-	for isWS(s.Peek()) || s.Peek() == '/' {
+	for scan.ByteIsWS(s.Peek()) || s.Peek() == '/' {
 		s.Advance(1)
 	}
 	if s.Peek() == '>' {
@@ -323,15 +323,15 @@ func getAnAttribute(s *scan.Bytes) (name, val string, hasMore bool) {
 		if bap == '=' && len(nameB) > 0 {
 			val, hasMore := getAValue(s)
 			return string(nameB), string(val), hasMore
-		} else if isWS(bap) {
-			for isWS(s.Peek()) {
+		} else if scan.ByteIsWS(bap) {
+			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			if s.Peek() != '=' {
 				return string(nameB), "", true
 			}
 			s.Advance(1)
-			for isWS(s.Peek()) {
+			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			val, hasMore := getAValue(s)
@@ -347,7 +347,7 @@ func getAnAttribute(s *scan.Bytes) (name, val string, hasMore bool) {
 }
 
 func getAValue(s *scan.Bytes) (_ []byte, hasMore bool) {
-	for isWS(s.Peek()) {
+	for scan.ByteIsWS(s.Peek()) {
 		s.Advance(1)
 	}
 	origS, end := *s, 0
@@ -375,7 +375,7 @@ func getAValue(s *scan.Bytes) (_ []byte, hasMore bool) {
 			return nil, false
 		}
 		switch {
-		case isWS(bap):
+		case scan.ByteIsWS(bap):
 			return origS[:end], true
 		case bap == '>':
 			return origS[:end], false
@@ -383,8 +383,4 @@ func getAValue(s *scan.Bytes) (_ []byte, hasMore bool) {
 			end++
 		}
 	}
-}
-
-func isWS(bap byte) bool {
-	return bap == '\t' || bap == '\n' || bap == '\x0c' || bap == '\r' || bap == ' '
 }

--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -359,18 +359,11 @@ func getAValue(s *scan.Bytes) (_ []byte, hasMore bool) {
 	// Step 10
 	switch bap {
 	case '"', '\'':
-		// quote loop
-		for {
-			c := s.Pop()
-			if c == 0 {
-				return nil, false
-			}
-			if bap == c {
-				// 1 to skip the quote at the beginning
-				return origS[1:end], s.Peek() != 0 && s.Peek() != '>'
-			}
-			end++
+		val := s.PopUntil(bap)
+		if s.Pop() != bap {
+			return nil, false
 		}
+		return val, s.Peek() != 0 && s.Peek() != '>'
 	case '>':
 		return nil, false
 	}

--- a/internal/json/parser_test.go
+++ b/internal/json/parser_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
 var sample = []byte(` { "type": "Feature", "fruit": "Apple", "size": "Large", "color": "Red" } `)
@@ -610,12 +612,13 @@ func testTruncating(t *testing.T, jsonString string) {
 	t.Helper()
 	p := &parserState{}
 	for i := 1; i <= len(jsonString); i++ {
-		trunc := trimRWS([]byte(jsonString)[:i])
+		b := scan.Bytes(jsonString[:i])
+		b.TrimRWS()
 		p.reset()
-		_ = p.consumeAny(trunc, nil, 0)
-		if p.ib != len(trunc) {
+		_ = p.consumeAny(b, nil, 0)
+		if p.ib != len(b) {
 			t.Errorf("truncated positives should be fully parsed %v \n"+
-				"got: %d want: %d", string(trunc), p.ib, len(trunc))
+				"got: %d want: %d", string(b), p.ib, len(b))
 		}
 	}
 }
@@ -799,16 +802,4 @@ func FuzzJson(f *testing.F) {
 		p.consumeObject(data, nil, 1)
 		p.consumeAny(data, nil, 1)
 	})
-}
-
-// trimRWS trims whitespace from the end of the input.
-func trimRWS(in []byte) []byte {
-	lastNonWS := len(in) - 1
-	for ; lastNonWS > 0 && isWS(in[lastNonWS]); lastNonWS-- {
-	}
-
-	return in[:lastNonWS+1]
-}
-func isWS(b byte) bool {
-	return b == '\t' || b == '\n' || b == '\x0c' || b == '\r' || b == ' '
 }

--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -4,6 +4,8 @@ package magic
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
 type (
@@ -74,12 +76,13 @@ func ciCheck(sig, raw []byte) bool {
 // matches the raw input.
 func xml(sigs ...xmlSig) Detector {
 	return func(raw []byte, limit uint32) bool {
-		raw = trimLWS(raw)
-		if len(raw) == 0 {
+		b := scan.Bytes(raw)
+		b.TrimLWS()
+		if len(b) == 0 {
 			return false
 		}
 		for _, s := range sigs {
-			if xmlCheck(s, raw) {
+			if xmlCheck(s, b) {
 				return true
 			}
 		}
@@ -104,19 +107,19 @@ func xmlCheck(sig xmlSig, raw []byte) bool {
 // matches the raw input.
 func markup(sigs ...[]byte) Detector {
 	return func(raw []byte, limit uint32) bool {
-		if bytes.HasPrefix(raw, []byte{0xEF, 0xBB, 0xBF}) {
+		b := scan.Bytes(raw)
+		if bytes.HasPrefix(b, []byte{0xEF, 0xBB, 0xBF}) {
 			// We skip the UTF-8 BOM if present to ensure we correctly
 			// process any leading whitespace. The presence of the BOM
 			// is taken into account during charset detection in charset.go.
-			raw = trimLWS(raw[3:])
-		} else {
-			raw = trimLWS(raw)
+			b.Advance(3)
 		}
-		if len(raw) == 0 {
+		b.TrimLWS()
+		if len(b) == 0 {
 			return false
 		}
 		for _, s := range sigs {
-			if markupCheck(s, raw) {
+			if markupCheck(s, b) {
 				return true
 			}
 		}
@@ -183,8 +186,10 @@ func newXMLSig(localName, xmlns string) xmlSig {
 // /usr/bin/env is the interpreter, php is the first and only argument.
 func shebang(sigs ...[]byte) Detector {
 	return func(raw []byte, limit uint32) bool {
+		b := scan.Bytes(raw)
+		line := b.Line()
 		for _, s := range sigs {
-			if shebangCheck(s, firstLine(raw)) {
+			if shebangCheck(s, line) {
 				return true
 			}
 		}
@@ -192,7 +197,7 @@ func shebang(sigs ...[]byte) Detector {
 	}
 }
 
-func shebangCheck(sig, raw []byte) bool {
+func shebangCheck(sig []byte, raw scan.Bytes) bool {
 	if len(raw) < len(sig)+2 {
 		return false
 	}
@@ -200,37 +205,10 @@ func shebangCheck(sig, raw []byte) bool {
 		return false
 	}
 
-	return bytes.Equal(trimLWS(trimRWS(raw[2:])), sig)
-}
-
-// trimLWS trims whitespace from beginning of the input.
-func trimLWS(in []byte) []byte {
-	firstNonWS := 0
-	for ; firstNonWS < len(in) && isWS(in[firstNonWS]); firstNonWS++ {
-	}
-
-	return in[firstNonWS:]
-}
-
-// trimRWS trims whitespace from the end of the input.
-func trimRWS(in []byte) []byte {
-	lastNonWS := len(in) - 1
-	for ; lastNonWS > 0 && isWS(in[lastNonWS]); lastNonWS-- {
-	}
-
-	return in[:lastNonWS+1]
-}
-
-func firstLine(in []byte) []byte {
-	lineEnd := 0
-	for ; lineEnd < len(in) && in[lineEnd] != '\n'; lineEnd++ {
-	}
-
-	return in[:lineEnd]
-}
-
-func isWS(b byte) bool {
-	return b == '\t' || b == '\n' || b == '\x0c' || b == '\r' || b == ' '
+	raw.Advance(2) // skip #! we checked above
+	raw.TrimLWS()
+	raw.TrimRWS()
+	return bytes.Equal(raw, sig)
 }
 
 func min(a, b int) int {
@@ -238,14 +216,4 @@ func min(a, b int) int {
 		return a
 	}
 	return b
-}
-
-type readBuf []byte
-
-func (b *readBuf) advance(n int) bool {
-	if n < 0 || len(*b) < n {
-		return false
-	}
-	*b = (*b)[n:]
-	return true
 }

--- a/internal/magic/magic_test.go
+++ b/internal/magic/magic_test.go
@@ -1,7 +1,6 @@
 package magic
 
 import (
-	"bufio"
 	"strings"
 	"testing"
 )
@@ -108,117 +107,6 @@ func TestMagic(t *testing.T) {
 				t.Errorf("empty input: expected: %t; got: %t", false, got)
 			}
 		})
-	}
-}
-
-func TestScanLine(t *testing.T) {
-	tcases := []struct {
-		name     string
-		input    string
-		expected []string
-	}{{
-		name:     "empty input",
-		input:    "",
-		expected: nil,
-	}, {
-		name:     "single line, no terminal nl",
-		input:    "1",
-		expected: []string{"1"},
-	}, {
-		name:     "single line, terminal nl",
-		input:    "1\n",
-		expected: []string{"1"},
-	}, {
-		name:     "two lines, no terminal nl",
-		input:    "1\n2",
-		expected: []string{"1", "2"},
-	}, {
-		name:     "two lines, with terminal nl",
-		input:    "1\n2\n",
-		expected: []string{"1", "2"},
-	}, {
-		name:     "drops final cr",
-		input:    "1\n2\r",
-		expected: []string{"1", "2"},
-	}, {
-		name:     "final empty line",
-		input:    "1\n2\n\n",
-		expected: []string{"1", "2", ""},
-	}, {
-		name:     "empty line with cr",
-		input:    "1\n2\n\r",
-		expected: []string{"1", "2", ""},
-	}, {
-		name:     "nd-json numbers and object",
-		input:    "1\n2\n3\n{}",
-		expected: []string{"1", "2", "3", "{}"},
-	},
-	}
-
-	for _, tt := range tcases {
-		t.Run(tt.name, func(t *testing.T) {
-			testScanLine(t, tt.input, tt.expected)
-			testScanLineLikeBufioScanner(t, tt.input)
-		})
-	}
-}
-
-func testScanLine(t *testing.T, text string, expectedLines []string) {
-	var l []byte
-	i, raw := 0, []byte(text)
-	for i = 0; len(raw) != 0; i++ {
-		l, raw = scanLine(raw)
-		if string(l) != expectedLines[i] {
-			t.Errorf("expected %q, got %q", expectedLines[i], l)
-		}
-	}
-	if i != len(expectedLines) {
-		t.Errorf("expected %d lines, got %d lines", len(expectedLines), i)
-	}
-}
-
-// Test that scanLine behaves exactly like bufio.Scanner.
-func testScanLineLikeBufioScanner(t *testing.T, text string) {
-	var l []byte
-	raw := []byte(text)
-	s := bufio.NewScanner(strings.NewReader(text))
-	for lineNum := 0; s.Scan(); lineNum++ {
-		l, raw = scanLine(raw)
-		if string(l) != s.Text() {
-			t.Errorf("expected: %q, got: %q", s.Text(), string(l))
-		}
-	}
-	if err := s.Err(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestDropLastLine(t *testing.T) {
-	dropTests := []struct {
-		raw   string
-		cutAt uint32
-		res   string
-	}{
-		{"", 0, ""},
-		{"", 1, ""},
-		{"å", 2, "å"},
-		{"\n", 0, "\n"},
-		{"\n", 1, "\n"},
-		{"\n\n", 1, "\n"},
-		{"\n\n", 3, "\n\n"},
-		{"a\n\n", 3, "a\n"},
-		{"\na\n", 3, "\na"},
-		{"å\n\n", 5, "å\n\n"},
-		{"\nå\n", 5, "\nå\n"},
-		// JSON with new-lines inside string value.
-		{"{\"a\" : \"b\\n\\n\"}", 5, "{\"a\" : \"b\\n\\n\"}"},
-		{"{\"a\" : \"b\\n\\n\"}", 100, "{\"a\" : \"b\\n\\n\"}"},
-	}
-	for i, tt := range dropTests {
-		got := dropLastLine([]byte(tt.raw), tt.cutAt)
-		if got := string(got); got != tt.res {
-			t.Errorf("dropLastLine %d error: expected %q; got %q", i, tt.res, got)
-		}
 	}
 }
 

--- a/internal/magic/zip.go
+++ b/internal/magic/zip.go
@@ -3,6 +3,8 @@ package magic
 import (
 	"bytes"
 	"encoding/binary"
+
+	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
 var (
@@ -46,13 +48,13 @@ func Jar(raw []byte, limit uint32) bool {
 }
 
 func zipContains(raw, sig []byte, msoCheck bool) bool {
-	b := readBuf(raw)
+	b := scan.Bytes(raw)
 	pk := []byte("PK\003\004")
 	if len(b) < 0x1E {
 		return false
 	}
 
-	if !b.advance(0x1E) {
+	if !b.Advance(0x1E) {
 		return false
 	}
 	if bytes.HasPrefix(b, sig) {
@@ -81,12 +83,12 @@ func zipContains(raw, sig []byte, msoCheck bool) bool {
 	}
 
 	searchOffset := binary.LittleEndian.Uint32(raw[18:]) + 49
-	if !b.advance(int(searchOffset)) {
+	if !b.Advance(int(searchOffset)) {
 		return false
 	}
 
 	nextHeader := bytes.Index(raw[searchOffset:], pk)
-	if !b.advance(nextHeader) {
+	if !b.Advance(nextHeader) {
 		return false
 	}
 	if bytes.HasPrefix(b, sig) {
@@ -94,14 +96,14 @@ func zipContains(raw, sig []byte, msoCheck bool) bool {
 	}
 
 	for i := 0; i < 4; i++ {
-		if !b.advance(0x1A) {
+		if !b.Advance(0x1A) {
 			return false
 		}
 		nextHeader = bytes.Index(b, pk)
 		if nextHeader == -1 {
 			return false
 		}
-		if !b.advance(nextHeader + 0x1E) {
+		if !b.Advance(nextHeader + 0x1E) {
 			return false
 		}
 		if bytes.HasPrefix(b, sig) {

--- a/internal/scan/bytes.go
+++ b/internal/scan/bytes.go
@@ -1,6 +1,8 @@
 // Package scan has functions for scanning byte slices.
 package scan
 
+import "bytes"
+
 // Bytes is a byte slice with helper methods for easier scanning.
 type Bytes []byte
 
@@ -45,26 +47,31 @@ func (b *Bytes) Pop() byte {
 	return 0
 }
 
-func (b *Bytes) PopUntil(anyChar ...byte) []byte {
-	i := 0
-	for ; i < len(*b); i++ {
-		if equalsAny((*b)[i], anyChar...) {
-			break
-		}
+// PopUntil will advance b until, but not including, the first occurence of stopAt
+// character. If no occurence is found, then it will advance until the end of b.
+// The returned Bytes is a slice of all the bytes that we're advanced over.
+func (b *Bytes) PopUntil(stopAt ...byte) Bytes {
+	if len(*b) == 0 {
+		return Bytes{}
+	}
+	i := bytes.IndexAny(*b, string(stopAt))
+	if i == -1 {
+		i = len(*b)
 	}
 
 	prefix := (*b)[:i]
 	*b = (*b)[i:]
-	return prefix
+	return Bytes(prefix)
 }
 
-func equalsAny(needle byte, haystack ...byte) bool {
-	for _, c := range haystack {
-		if needle == c {
-			return true
+// Is will return true if all bytes in b are one of the allowed bytes.
+func (b *Bytes) Is(allowed []byte) bool {
+	for _, c := range *b {
+		if bytes.IndexByte(allowed, c) == -1 {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // First line returns the first line from b and advances b with the length of the
@@ -86,3 +93,8 @@ func (b *Bytes) FirstLine() []byte {
 func isWS(b byte) bool {
 	return b == '\t' || b == '\n' || b == '\x0c' || b == '\r' || b == ' '
 }
+
+var (
+	ASCIISpaces = []byte{' ', '\r', '\n', '\x0c', '\t'}
+	ASCIIDigits = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+)

--- a/internal/scan/bytes_test.go
+++ b/internal/scan/bytes_test.go
@@ -206,3 +206,38 @@ func TestPopUntil(t *testing.T) {
 		})
 	}
 }
+
+func TestIs(t *testing.T) {
+	tcases := []struct {
+		name    string
+		in      string
+		allowed string
+		want    bool
+	}{{
+		"both empty", "", "", true,
+	}, {
+		"allowed empty", "123", "", false,
+	}, {
+		"in empty", "", "1", true,
+	}, {
+		"123 4", "123", "4", false,
+	}, {
+		"123 456", "123", "456", false,
+	}, {
+		"123 23", "123", "23", false,
+	}, {
+		"123 234", "123", "234", false,
+	}, {
+		"123 1234", "123", "1234", true,
+	}}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := Bytes(tc.in)
+			got := b.Is([]byte(tc.allowed))
+			if tc.want != got {
+				t.Errorf("got: %t, want: %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scan/bytes_test.go
+++ b/internal/scan/bytes_test.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"bufio"
+	"strings"
 	"testing"
 )
 
@@ -132,7 +134,7 @@ func TestAdvance(t *testing.T) {
 	}
 }
 
-func TestFirstLine(t *testing.T) {
+func TestLine(t *testing.T) {
 	tcases := []struct {
 		name     string
 		in       string
@@ -152,17 +154,30 @@ func TestFirstLine(t *testing.T) {
 		"two lines", "abc\ndef", "abc", "def",
 	}, {
 		"two lines with \\n", "abc\ndef\n", "abc", "def\n",
+	}, {
+		"drops final cr", "abc\r", "abc", "",
+	}, {
+		"cr inside line", "abc\rdef", "abc\rdef", "",
+	}, {
+		"nl and cr", "\n\r", "", "\r",
 	}}
 
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			b := Bytes(tc.in)
-			line := b.FirstLine()
+			line := b.Line()
 			if string(line) != tc.line {
 				t.Errorf("line: got: %s, want: %s", line, []byte(tc.line))
 			}
 			if string(b) != tc.leftover {
 				t.Errorf("leftover: got: %s, want: %s", b, []byte(tc.leftover))
+			}
+
+			// Test if it behaves like bufio.Scanner as well.
+			s := bufio.NewScanner(strings.NewReader(tc.in))
+			s.Scan()
+			if string(line) != s.Text() {
+				t.Errorf("Bytes.Line not like bufio.Scanner")
 			}
 		})
 	}


### PR DESCRIPTION
Previously, bytes functions were scattered wherever they were needed (with some duplication and behaviour variation)
After this PR: a single implementation for various bytes functions.