### PR TITLE
csv: stop mutating input byte slices; for #680

### DIFF
--- a/internal/csv/parser.go
+++ b/internal/csv/parser.go
@@ -20,35 +20,20 @@ func NewParser(comma, comment byte, s scan.Bytes) *Parser {
 	}
 }
 
-func (r *Parser) readLine() []byte {
-	line := r.s.ReadSlice('\n')
-	n := len(line)
-	if n > 0 && line[n-1] == '\r' {
-		return line[:n-1] // drop \r at end of line
-	}
-
-	// Normalize \r\n to \n on all input lines.
-	if n := len(line); n >= 2 && line[n-2] == '\r' && line[n-1] == '\n' {
-		line[n-2] = '\n'
-		return line[:n-1]
-	}
-	return line
-}
-
 // CountFields reads one CSV line and counts how many records that line contained.
 // hasMore reports whether there are more lines in the input.
 func (r *Parser) CountFields() (fields int, hasMore bool) {
 	finished := false
 	var line scan.Bytes
 	for {
-		line = r.readLine()
+		line = r.s.ReadSlice('\n')
 		if finished {
 			return 0, false
 		}
 		finished = len(r.s) == 0 && len(line) == 0
 		if len(line) == lengthNL(line) {
 			line = nil
-			continue // Skip empty lines
+			continue // Skip empty lines.
 		}
 		if len(line) > 0 && line[0] == r.comment {
 			line = nil
@@ -85,7 +70,7 @@ parseField:
 						break parseField
 					}
 				} else if len(line) > 0 {
-					line = r.readLine()
+					line = r.s.ReadSlice('\n')
 				} else {
 					fields++
 					break parseField

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -80,6 +80,12 @@ a,"b`,
 		"text/csv",
 		true,
 	},
+	{
+		`csv with \r\n`,
+		"1,2\r\n3,4\r\na,b",
+		"text/csv",
+		false,
+	},
 	{"cpio 7", "070707", "application/x-cpio", true},
 	{"cpio 1", "070701", "application/x-cpio", false},
 	{"cpio 2", "070702", "application/x-cpio", false},
@@ -647,4 +653,17 @@ func FuzzMimetype(f *testing.F) {
 			t.Skip()
 		}
 	})
+}
+
+func TestInputIsNotMutated(t *testing.T) {
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			passedBytes := []byte(tc.data)
+			Detect(passedBytes)
+
+			if pbs := string(passedBytes); pbs != tc.data {
+				t.Errorf("input should not be mutated; before: %s, after: %s", tc.data, pbs)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This commit fixes an occurence where \r\n inside input bytes would be overwritten by \n\n. It also adds a test that checks inputs are not overwritten.