### PR TITLE
CSV fix fuzzing tests

### DIFF
--- a/internal/csv/parser.go
+++ b/internal/csv/parser.go
@@ -6,6 +6,9 @@ import (
 	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
+// Parser is a CSV reader that only counts fields.
+// It avoids allocating/copying memory and to verify behaviour, it is tested
+// and fuzzed against encoding/csv parser.
 type Parser struct {
 	comma   byte
 	comment byte
@@ -20,15 +23,30 @@ func NewParser(comma, comment byte, s scan.Bytes) *Parser {
 	}
 }
 
+func (r *Parser) readLine() []byte {
+	line := r.s.ReadSlice('\n')
+	n := len(line)
+	if n > 0 && line[n-1] == '\r' {
+		return line[:n-1] // drop \r at end of line
+	}
+
+	// Normalize \r\n to \n on all input lines.
+	if n := len(line); n >= 2 && line[n-2] == '\r' && line[n-1] == '\n' {
+		line[n-2] = '\n'
+		return line[:n-1]
+	}
+	return line
+}
+
 // CountFields reads one CSV line and counts how many records that line contained.
 // hasMore reports whether there are more lines in the input.
-func (r *Parser) CountFields() (fields int, hasMore bool) {
+func (r *Parser) CountFields(collectIndexes bool) (fields int, fieldPos []int, hasMore bool) {
 	finished := false
 	var line scan.Bytes
 	for {
-		line = r.s.ReadSlice('\n')
+		line = r.readLine()
 		if finished {
-			return 0, false
+			return 0, nil, false
 		}
 		finished = len(r.s) == 0 && len(line) == 0
 		if len(line) == lengthNL(line) {
@@ -42,10 +60,15 @@ func (r *Parser) CountFields() (fields int, hasMore bool) {
 		break
 	}
 
+	indexes := []int{}
+	originalLine := line
 parseField:
 	for {
 		if len(line) == 0 || line[0] != '"' { // non-quoted string field
 			fields++
+			if collectIndexes {
+				indexes = append(indexes, len(originalLine)-len(line))
+			}
 			i := bytes.IndexByte(line, r.comma)
 			if i >= 0 {
 				line.Advance(i + 1) // 1 to get over ending comma
@@ -53,6 +76,9 @@ parseField:
 			}
 			break parseField
 		} else { // Quoted string field.
+			if collectIndexes {
+				indexes = append(indexes, len(originalLine)-len(line))
+			}
 			line.Advance(1) // get over starting quote
 			for {
 				i := bytes.IndexByte(line, '"')
@@ -70,7 +96,8 @@ parseField:
 						break parseField
 					}
 				} else if len(line) > 0 {
-					line = r.s.ReadSlice('\n')
+					line = r.readLine()
+					originalLine = line
 				} else {
 					fields++
 					break parseField
@@ -79,7 +106,7 @@ parseField:
 		}
 	}
 
-	return fields, fields != 0
+	return fields, indexes, fields != 0
 }
 
 // lengthNL reports the number of bytes for the trailing \n.

--- a/internal/csv/parser_test.go
+++ b/internal/csv/parser_test.go
@@ -202,12 +202,17 @@ func BenchmarkCSVStdlibDecoder(b *testing.B) {
 	// Reuse a single reader to prevent allocs inside the benchmark function.
 	r := strings.NewReader(sample)
 	for i := 0; i < b.N; i++ {
-		r.Seek(0, 0)
+		_, err := r.Seek(0, 0)
+		if err != nil {
+			b.Fatalf("reader cannot seek: %s", err)
+		}
 		d := csv.NewReader(r)
 		for {
 			_, err := d.Read()
 			if err == io.EOF {
 				break
+			} else if err != nil {
+				b.Fatalf("error parsing CSV: %s", err)
 			}
 		}
 	}

--- a/internal/csv/parser_test.go
+++ b/internal/csv/parser_test.go
@@ -207,6 +207,9 @@ func BenchmarkCSVStdlibDecoder(b *testing.B) {
 			b.Fatalf("reader cannot seek: %s", err)
 		}
 		d := csv.NewReader(r)
+		d.ReuseRecord = true
+		d.FieldsPerRecord = -1 // we don't care about lines having same number of fields
+		d.LazyQuotes = true
 		for {
 			_, err := d.Read()
 			if err == io.EOF {

--- a/internal/magic/text_csv.go
+++ b/internal/magic/text_csv.go
@@ -20,13 +20,13 @@ func sv(in []byte, comma byte, limit uint32) bool {
 	s.DropLastLine(limit)
 	r := csv.NewParser(comma, '#', s)
 
-	headerFields, hasMore := r.CountFields()
+	headerFields, _, hasMore := r.CountFields(false)
 	if headerFields < 2 || !hasMore {
 		return false
 	}
 	csvLines := 1 // 1 for header
 	for {
-		fields, hasMore := r.CountFields()
+		fields, _, hasMore := r.CountFields(false)
 		if !hasMore && fields == 0 {
 			break
 		}


### PR DESCRIPTION
#680 reported that the input passed to detection functions is getting altered.
#681 fixed the problem and all tests were passing. However, fuzzing was not passing.

This PR fixes the CSV parser so fuzzing tests are green too. Additionally, tests for CSV show more useful information: they now report both the way encoding/csv.Reader breaks an input into CSV fields compared to the way our Parser does it.