### PR TITLE
mso_office: increase limit of checked entries from 4 to 100

### DIFF
--- a/internal/magic/zip.go
+++ b/internal/magic/zip.go
@@ -95,7 +95,13 @@ func zipContains(raw, sig []byte, msoCheck bool) bool {
 		return true
 	}
 
-	for i := 0; i < 4; i++ {
+	// Previously i was 4 at max, but #679 reported zip files where signatures
+	// occur later than 4. Because mimetype only looks at the file header, this
+	// for loop might as well be unbounded, ie: until the input bytes are all
+	// consumed. But users can call SetLimit(0) to make mimetype analyze whole
+	// files. So keep max 100 just in case. The reason I initially made it 4
+	// was because FILE(1) had this limit.
+	for i := 0; i < 100; i++ {
 		if !b.Advance(0x1A) {
 			return false
 		}

--- a/internal/magic/zip_test.go
+++ b/internal/magic/zip_test.go
@@ -96,6 +96,27 @@ func TestZeroZip(t *testing.T) {
 		name:  "1 2 3 4 5 6 META-INF", // we only check first 6 files
 		files: []string{"1", "2", "3", "4", "5", "6", "META-INF/MANIFEST.MF"},
 		jar:   false,
+	}, {
+		name: "ppt/ after 15 files",
+		files: []string{
+			"[Content_Types].xml",
+			"_rels/.rels",
+			"customXml/_rels/item1.xml",
+			"customXml/_rels/item2.xml.rels",
+			"customXml/_rels/item3.xml.rels",
+			"customXml/_rels/item4.xml.rels",
+			"customXml/item1.xml",
+			"customXml/item2.xml",
+			"customXml/item3.xml",
+			"customXml/itemProps1.xml",
+			"customXml/itemProps2.xml",
+			"customXml/itemProps3.xml",
+			"docProps/app.xml",
+			"docProps/core.xml",
+			"docProps/custom.xml",
+			"ppt/_rels/presentation.xml.rel",
+		},
+		pptx: true,
 	}}
 
 	for _, tc := range tcases {


### PR DESCRIPTION
Previously i was 4 at max, but #679 reported zip files where signatures occur later than 4. Because mimetype only looks at the file header, this for loop might as well be unbounded, ie: until the input bytes are all consumed. 

But users can call SetLimit(0) to make mimetype analyze whole files. So keep max 100 just in case. The reason I initially made it 4 was because FILE(1) had this limit.