### PR TITLE
misc: behave more like file

### DIFF
--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -142,7 +142,7 @@ func markupCheck(sig, raw []byte) bool {
 		}
 	}
 	// Next byte must be space or right angle bracket.
-	if db := raw[len(sig)]; db != ' ' && db != '>' {
+	if db := raw[len(sig)]; !scan.ByteIsWS(db) && db != '>' {
 		return false
 	}
 

--- a/internal/magic/text_csv.go
+++ b/internal/magic/text_csv.go
@@ -34,6 +34,9 @@ func sv(in []byte, comma byte, limit uint32) bool {
 		if fields != headerFields {
 			return false
 		}
+		if csvLines >= 10 {
+			return true
+		}
 	}
 
 	return csvLines >= 2

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -61,7 +61,7 @@ Extension | MIME type | Aliases
 **.tar** | application/x-tar | -
 **.xar** | application/x-xar | -
 **.bz2** | application/x-bzip2 | -
-**.fits** | application/fits | -
+**.fits** | application/fits | image/fits
 **.tiff** | image/tiff | -
 **.bmp** | image/bmp | image/x-bmp, image/x-ms-bmp
 **.ico** | image/x-icon | -

--- a/tree.go
+++ b/tree.go
@@ -76,7 +76,7 @@ var (
 		alias("application/msexcel")
 	msg  = newMIME("application/vnd.ms-outlook", ".msg", magic.Msg)
 	ps   = newMIME("application/postscript", ".ps", magic.Ps)
-	fits = newMIME("application/fits", ".fits", magic.Fits)
+	fits = newMIME("application/fits", ".fits", magic.Fits).alias("image/fits")
 	ogg  = newMIME("application/ogg", ".ogg", magic.Ogg, oggAudio, oggVideo).
 		alias("application/x-ogg")
 	oggAudio = newMIME("audio/ogg", ".oga", magic.OggAudio)


### PR DESCRIPTION
html: previously, just 0x20 spaces where used as html tags separator
          after, any space can be used

csv:  file only reads up to 10 CSV lines and we we're reading unlimited 

fits: in addition to application/fits, which is specified by IANA, image/fits is also used, so add it as alias