### PR TITLE
benchmark: keep input allocation outside of benchmark

### DIFF
--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -584,11 +584,12 @@ func BenchmarkAll(b *testing.B) {
 		if tc.bench != all {
 			continue
 		}
+		data := []byte(tc.data)
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
 				// Benchmark both positive and negative.
-				Detect([]byte(tc.data))
+				Detect(data)
 				Detect(randData)
 			}
 		})
@@ -708,6 +709,7 @@ func FuzzMimetype(f *testing.F) {
 	})
 }
 
+// For #680.
 func TestInputIsNotMutated(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Previously, the input byte allocation was done inside the benchmark function. That means the input itself counted towards memory allocation statistics. This creates an unfair comparison because some input files are bigger than others.

This commit puts the allocation outside the benchmark function.