### PR TITLE
Xhtml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,10 +20,10 @@ jobs:
       with:
         go-version: 'stable'
     - run: go install golang.org/x/perf/cmd/benchstat@latest
-    - run: go test -run=none -bench=. -count=10 -benchtime=200ms -timeout=1h ./... > /tmp/prev
+    - run: go test -run=none -bench=. -count=7 -benchtime=200ms -timeout=1h ./... > /tmp/prev
     - name: Checkout code
       uses: actions/checkout@v5.0.0
     # Second run of benchmarks
-    - run: go test -run=none -bench=. -count=10 -benchtime=200ms -timeout=1h ./... > /tmp/curr
+    - run: go test -run=none -bench=. -count=7 -benchtime=200ms -timeout=1h ./... > /tmp/curr
 
     - run: benchstat /tmp/prev /tmp/curr

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,8 @@ jobs:
     # Base for comparison is master branch.
     - name: Checkout code
       uses: actions/checkout@v5.0.0
+      with:
+        ref: master
     - name: Install Go
       uses: actions/setup-go@v6.0.0
       with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,11 +19,15 @@ jobs:
         go-version-file: 'go.mod'
     # 3m is chosen so that half of the 2000 free CI minutes offered by Github
     # will be used each month. The other half is reserved for tests in PRs.
-    - run: go test -fuzztime=3m -fuzz=.
-    - run: go test -fuzztime=3m -fuzz=.     ./internal/json
-    - run: go test -fuzztime=3m -fuzz=.     ./internal/csv
-    - run: go test -fuzztime=3m -fuzz=.     ./internal/scan
-    - run: go test -fuzztime=3m -fuzz=Plain ./internal/charset
-    - run: go test -fuzztime=3m -fuzz=XML   ./internal/charset
-    - run: go test -fuzztime=3m -fuzz=HTML  ./internal/charset
-    - run: go test -fuzztime=3m -fuzz=HTML  ./internal/charset
+    # TODO: Find a way to select all fuzz tests, without listing them individually.
+    - run: go test -fuzztime=3m -fuzz=Mimetype        ./
+    - run: go test -fuzztime=3m -fuzz=Search          ./internal/scan
+    - run: go test -fuzztime=3m -fuzz=Match           ./internal/scan
+    - run: go test -fuzztime=3m -fuzz=Json            ./internal/json
+    - run: go test -fuzztime=3m -fuzz=Parser          ./internal/csv
+    - run: go test -fuzztime=3m -fuzz=Plain           ./internal/charset
+    - run: go test -fuzztime=3m -fuzz=XML             ./internal/charset
+    - run: go test -fuzztime=3m -fuzz=HTML            ./internal/charset
+    - run: go test -fuzztime=3m -fuzz=Meta            ./internal/charset
+    - run: go test -fuzztime=3m -fuzz=GetAnAttribute  ./internal/markup
+    - run: go test -fuzztime=3m -fuzz=GetAValue       ./internal/markup

--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -153,7 +153,7 @@ func fromXML(s scan.Bytes) string {
 		if len(s) <= lxml {
 			return ""
 		}
-		if !s.Match(xml, scan.IgnoreCase) {
+		if s.Match(xml, scan.IgnoreCase) == -1 {
 			s = s[1:] // safe to slice instead of s.Advance(1) because bounds are checked
 			continue
 		}
@@ -198,10 +198,10 @@ func fromHTML(s scan.Bytes) string {
 			return ""
 		}
 		// Abort when <body is reached.
-		if s.Match(body, scan.IgnoreCase) {
+		if s.Match(body, scan.IgnoreCase) != -1 {
 			return ""
 		}
-		if !s.Match(meta, scan.IgnoreCase) {
+		if s.Match(meta, scan.IgnoreCase) == -1 {
 			s = s[1:] // safe to slice instead of s.Advance(1) because bounds are checked
 			continue
 		}
@@ -231,8 +231,10 @@ func fromHTML(s scan.Bytes) string {
 				}
 			}
 			attrList[aName] = true
-			if aName == "http-equiv" && scan.Bytes(aVal).Match([]byte("CONTENT-TYPE"), scan.IgnoreCase) {
-				gotPragma = true
+			if aName == "http-equiv" {
+				if scan.Bytes(aVal).Match([]byte("CONTENT-TYPE"), scan.IgnoreCase) != -1 {
+					gotPragma = true
+				}
 			} else if aName == "content" {
 				charset = string(extractCharsetFromMeta(scan.Bytes(aVal)))
 				if len(charset) != 0 {

--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -231,16 +231,17 @@ func fromHTML(s scan.Bytes) string {
 				}
 			}
 			attrList[aName] = true
-			if aName == "http-equiv" {
+			switch aName {
+			case "http-equiv":
 				if scan.Bytes(aVal).Match([]byte("CONTENT-TYPE"), scan.IgnoreCase) != -1 {
 					gotPragma = true
 				}
-			} else if aName == "content" {
+			case "content":
 				charset = string(extractCharsetFromMeta(scan.Bytes(aVal)))
 				if len(charset) != 0 {
 					needPragma = doNeedPragma
 				}
-			} else if aName == "charset" {
+			case "charset":
 				charset = aVal
 				needPragma = doNotNeedPragma
 			}

--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -184,7 +184,7 @@ func newXMLSig(localName, xmlns string) xmlSig {
 //	#! /usr/bin/env php
 //
 // /usr/bin/env is the interpreter, php is the first and only argument.
-func shebang(sigs ...[]byte) Detector {
+func shebang(matchFlags scan.Flags, sigs ...[]byte) Detector {
 	return func(raw []byte, limit uint32) bool {
 		b := scan.Bytes(raw)
 		line := b.Line()
@@ -196,13 +196,7 @@ func shebang(sigs ...[]byte) Detector {
 		for _, s := range sigs {
 			// Make a copy of line because code inside this loop mutates the line
 			l := line
-			i := l.Match(s, scan.CompactWS)
-			if i == -1 {
-				continue
-			}
-			l.Advance(i)
-			// If we reached the end of a line or whitespace follows.
-			if len(l) == 0 || scan.ByteIsWS(l.Peek()) {
+			if l.Match(s, matchFlags) != -1 {
 				return true
 			}
 		}

--- a/internal/magic/magic_test.go
+++ b/internal/magic/magic_test.go
@@ -2,6 +2,8 @@ package magic
 
 import (
 	"testing"
+
+	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
 func TestShebangCheck(t *testing.T) {
@@ -9,6 +11,7 @@ func TestShebangCheck(t *testing.T) {
 		name     string
 		sig      []byte
 		input    string
+		flags    scan.Flags
 		expected bool
 	}{
 		// Valid shebangs
@@ -16,66 +19,77 @@ func TestShebangCheck(t *testing.T) {
 			name:     "valid bash shebang",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/bin/bash",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with spaces",
 			sig:      []byte("/bin/bash"),
 			input:    "#! /bin/bash",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with multiple spaces",
 			sig:      []byte("/bin/bash"),
 			input:    "#!   /bin/bash",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with tabs",
 			sig:      []byte("/bin/bash"),
 			input:    "#!\t/bin/bash",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with mixed whitespace",
 			sig:      []byte("/bin/bash"),
 			input:    "#! \t /bin/bash",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with trailing whitespace",
 			sig:      []byte("/bin/bash"),
 			input:    "#! /bin/bash \t ",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid bash shebang with arguments",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/bin/bash -exu",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid env/python shebang",
 			sig:      []byte("/usr/bin/env python"),
 			input:    "#!/usr/bin/env python",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid env/python shebang with spaces",
 			sig:      []byte("/usr/bin/env python"),
 			input:    "#! /usr/bin/env python",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid env/python shebang with arguments",
 			sig:      []byte("/usr/bin/env python"),
 			input:    "#!/usr/bin/env python -u",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "valid env/python shebang with arguments and trailing ws",
 			sig:      []byte("/usr/bin/env python"),
 			input:    "#!/usr/bin/env python -u \n",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 
@@ -84,42 +98,63 @@ func TestShebangCheck(t *testing.T) {
 			name:     "missing shebang prefix",
 			sig:      []byte("/bin/bash"),
 			input:    "/bin/bash",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "wrong shebang prefix",
 			sig:      []byte("/bin/bash"),
 			input:    "##!/bin/bash",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "wrong shebang prefix 2",
 			sig:      []byte("/bin/bash"),
 			input:    "!#/bin/bash",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "wrong interpreter path",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/bin/sh",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "partial interpreter path",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/bin/bas",
-			expected: false,
-		},
-		{
-			name:     "extra characters before interpreter",
-			sig:      []byte("/bin/bash"),
-			input:    "#!/bin/bashx",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "extra characters after interpreter",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/bin/bashx",
+			flags:    scan.CompactWS,
+			expected: true,
+		},
+		{
+			name:     "extra characters after interpreter but FullWord",
+			sig:      []byte("/bin/bash"),
+			input:    "#!/bin/bashx",
+			flags:    scan.CompactWS | scan.FullWord,
+			expected: false,
+		},
+		{
+			name:     "extra characters after env interpreter",
+			sig:      []byte("/usr/bin/env bash"),
+			input:    "#!/usr/bin/env bash123",
+			flags:    scan.CompactWS,
+			expected: true,
+		},
+		{
+			name:     "extra characters after env interpreter but FullWord",
+			sig:      []byte("/usr/bin/env bash"),
+			input:    "#!/usr/bin/env bash123",
+			flags:    scan.CompactWS | scan.FullWord,
 			expected: false,
 		},
 
@@ -128,67 +163,84 @@ func TestShebangCheck(t *testing.T) {
 			name:     "empty input",
 			sig:      []byte("/bin/bash"),
 			input:    "",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "too short input",
 			sig:      []byte("/bin/bash"),
 			input:    "#!",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "just shebang prefix",
 			sig:      []byte("/bin/bash"),
 			input:    "#!",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "shebang with only spaces",
 			sig:      []byte("/bin/bash"),
 			input:    "#!   ",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "shebang with only tabs",
 			sig:      []byte("/bin/bash"),
 			input:    "#!\t\t",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "empty signature",
 			sig:      []byte(""),
 			input:    "#!",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "empty signature with spaces",
 			sig:      []byte(""),
 			input:    "#!   ",
+			flags:    scan.CompactWS,
 			expected: true,
 		},
 		{
 			name:     "signature longer than input",
 			sig:      []byte("/very/long/path/to/interpreter"),
 			input:    "#!/bin/bash",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "case sensitivity test",
 			sig:      []byte("/bin/bash"),
 			input:    "#!/BIN/BASH",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 		{
 			name:     "case sensitivity test 2",
 			sig:      []byte("/BIN/BASH"),
 			input:    "#!/bin/bash",
+			flags:    scan.CompactWS,
+			expected: false,
+		},
+		{
+			name:     "case sensitivity test 2",
+			sig:      []byte("/BIN/BASH"),
+			input:    "#!/bin/bash",
+			flags:    scan.CompactWS,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := shebang(tt.sig)
+			d := shebang(tt.flags, tt.sig)
 			result := d([]byte(tt.input), 0)
 			if result != tt.expected {
 				t.Errorf("shebang(%q, %q) = %v, want %v", tt.sig, tt.input, result, tt.expected)

--- a/internal/magic/magic_test.go
+++ b/internal/magic/magic_test.go
@@ -2,8 +2,6 @@ package magic
 
 import (
 	"testing"
-
-	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
 func TestShebangCheck(t *testing.T) {
@@ -72,6 +70,12 @@ func TestShebangCheck(t *testing.T) {
 			name:     "valid env/python shebang with arguments",
 			sig:      []byte("/usr/bin/env python"),
 			input:    "#!/usr/bin/env python -u",
+			expected: true,
+		},
+		{
+			name:     "valid env/python shebang with arguments and trailing ws",
+			sig:      []byte("/usr/bin/env python"),
+			input:    "#!/usr/bin/env python -u \n",
 			expected: true,
 		},
 
@@ -184,11 +188,10 @@ func TestShebangCheck(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			raw := scan.Bytes([]byte(tt.input))
-			line := raw.Line()
-			result := shebangCheck(tt.sig, line)
+			d := shebang(tt.sig)
+			result := d([]byte(tt.input), 0)
 			if result != tt.expected {
-				t.Errorf("shebangCheck(%q, %q) = %v, want %v", tt.sig, tt.input, result, tt.expected)
+				t.Errorf("shebang(%q, %q) = %v, want %v", tt.sig, tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -79,12 +79,14 @@ var (
 		[]byte("<? "),
 	)
 	phpScriptF = shebang(
+		scan.CompactWS,
 		[]byte("/usr/local/bin/php"),
 		[]byte("/usr/bin/php"),
 		[]byte("/usr/bin/env php"),
 	)
 	// Js matches a Javascript file.
 	Js = shebang(
+		scan.CompactWS,
 		[]byte("/bin/node"),
 		[]byte("/usr/bin/node"),
 		[]byte("/bin/nodejs"),
@@ -94,17 +96,20 @@ var (
 	)
 	// Lua matches a Lua programming language file.
 	Lua = shebang(
+		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/lua"),
 		[]byte("/usr/local/bin/lua"),
 		[]byte("/usr/bin/env lua"),
 	)
 	// Perl matches a Perl programming language file.
 	Perl = shebang(
+		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/perl"),
 		[]byte("/usr/bin/env perl"),
 	)
 	// Python matches a Python programming language file.
 	Python = shebang(
+		scan.CompactWS,
 		[]byte("/usr/bin/python"),
 		[]byte("/usr/local/bin/python"),
 		[]byte("/usr/bin/env python"),
@@ -117,12 +122,14 @@ var (
 	)
 	// Ruby matches a Ruby programming language file.
 	Ruby = shebang(
+		scan.CompactWS,
 		[]byte("/usr/bin/ruby"),
 		[]byte("/usr/local/bin/ruby"),
 		[]byte("/usr/bin/env ruby"),
 	)
 	// Tcl matches a Tcl programming language file.
 	Tcl = shebang(
+		scan.CompactWS,
 		[]byte("/usr/bin/tcl"),
 		[]byte("/usr/local/bin/tcl"),
 		[]byte("/usr/bin/env tcl"),
@@ -137,6 +144,7 @@ var (
 	Rtf = prefix([]byte("{\\rtf"))
 	// Shell matches a shell script file.
 	Shell = shebang(
+		scan.CompactWS|scan.FullWord,
 		[]byte("/bin/sh"),
 		[]byte("/bin/bash"),
 		[]byte("/usr/local/bin/bash"),

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -185,8 +185,12 @@ func Text(raw []byte, _ uint32) bool {
 func XHTML(raw []byte, limit uint32) bool {
 	raw = raw[:min(len(raw), 4096)]
 	b := scan.Bytes(raw)
-	return b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase) != -1 ||
-		b.Search([]byte("<HTML XMLNS="), scan.CompactWS|scan.IgnoreCase) != -1
+	i, _ := b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase)
+	if i != -1 {
+		return true
+	}
+	i, _ = b.Search([]byte("<HTML XMLNS="), scan.CompactWS|scan.IgnoreCase)
+	return i != -1
 }
 
 // Php matches a PHP: Hypertext Preprocessor file.

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -306,11 +306,12 @@ func svgWithoutXMLDeclaration(s scan.Bytes) bool {
 		return false
 	}
 
-	targetName, targetVal := "xmlns", "http://www.w3.org/2000/svg"
-	aName, aVal, hasMore := "", "", true
+	targetName, targetVal := []byte("xmlns"), []byte("http://www.w3.org/2000/svg")
+	var aName, aVal []byte
+	hasMore := true
 	for hasMore {
 		aName, aVal, hasMore = mkup.GetAnAttribute(&s)
-		if aName == targetName && aVal == targetVal {
+		if bytes.Equal(aName, targetName) && bytes.Equal(aVal, targetVal) {
 			return true
 		}
 		if !hasMore {
@@ -337,10 +338,11 @@ func svgWithXMLDeclaration(s scan.Bytes) bool {
 
 	// version is a required attribute for XML.
 	hasVersion := false
-	aName, hasMore := "", true
+	var aName []byte
+	hasMore := true
 	for hasMore {
 		aName, _, hasMore = mkup.GetAnAttribute(&s)
-		if aName == "version" {
+		if bytes.Equal(aName, []byte("version")) {
 			hasVersion = true
 			break
 		}

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -191,7 +191,7 @@ func Text(raw []byte, _ uint32) bool {
 
 // XHTML matches an XHTML file. This check depends on the XML check to have passed.
 func XHTML(raw []byte, limit uint32) bool {
-	raw = raw[:min(len(raw), 4096)]
+	raw = raw[:min(len(raw), 1024)]
 	b := scan.Bytes(raw)
 	i, _ := b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase)
 	if i != -1 {

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -8,46 +8,50 @@ import (
 	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
-func GetAnAttribute(s *scan.Bytes) (name, val string, hasMore bool) {
+// GetAnAttribute assumes we passed over an SGML tag and extracts first
+// attribute and its value.
+//
+// Initially, this code existed inside charset/charset.go, because it was part of
+// implementing the https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+// algorithm. But because extracting an attribute from a tag is the same for
+// both HTML and XML, then the code was moved here.
+func GetAnAttribute(s *scan.Bytes) (name, val []byte, hasMore bool) {
 	for scan.ByteIsWS(s.Peek()) || s.Peek() == '/' {
 		s.Advance(1)
 	}
 	if s.Peek() == '>' {
-		return "", "", false
+		return nil, nil, false
 	}
-	// Allocate 10 to avoid resizes.
-	// Attribute names and values are continuous slices of bytes in input,
-	// so we could do without allocating and returning slices of input.
-	nameB := make([]byte, 0, 10)
+	origS, end := *s, 0
 	// step 4 and 5
 	for {
 		// bap means byte at position in the specification.
 		bap := s.Pop()
 		if bap == 0 {
-			return "", "", false
+			return nil, nil, false
 		}
-		if bap == '=' && len(nameB) > 0 {
+		if bap == '=' && end > 0 {
 			val, hasMore := getAValue(s)
-			return string(nameB), string(val), hasMore
+			return origS[:end], val, hasMore
 		} else if scan.ByteIsWS(bap) {
 			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			if s.Peek() != '=' {
-				return string(nameB), "", true
+				return origS[:end], nil, true
 			}
 			s.Advance(1)
 			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			val, hasMore := getAValue(s)
-			return string(nameB), string(val), hasMore
+			return origS[:end], val, hasMore
 		} else if bap == '/' || bap == '>' {
-			return string(nameB), "", false
+			return origS[:end], nil, false
 		} else if bap >= 'A' && bap <= 'Z' {
-			nameB = append(nameB, bap+0x20)
+			end++
 		} else {
-			nameB = append(nameB, bap)
+			end++
 		}
 	}
 }

--- a/internal/markup/markup_test.go
+++ b/internal/markup/markup_test.go
@@ -23,7 +23,7 @@ var getAnAttributeTestCases = []struct {
 }, {
 	"1>", "1", "", false,
 }, {
-	"A>", "a", "", false,
+	"A>", "A", "", false,
 }, {
 	"a>", "a", "", false,
 }, {
@@ -47,6 +47,8 @@ var getAnAttributeTestCases = []struct {
 	" meta6 =' meta '>", "meta6", " meta ", false,
 }, {
 	` meta7 =' "meta '>`, "meta7", ` "meta `, false,
+}, {
+	` mEtA7 =' "meta '>`, "mEtA7", ` "meta `, false,
 	// / as attribute ender
 }, {
 	// when the value is unquoted / right after is a parse warning
@@ -213,10 +215,10 @@ func TestGetAllAttributes(t *testing.T) {
 		ret := [][2]string{}
 		for {
 			name, value, _ := GetAnAttribute(&s)
-			if name == "" {
+			if len(name) == 0 {
 				return ret
 			}
-			ret = append(ret, [2]string{name, value})
+			ret = append(ret, [2]string{string(name), string(value)})
 		}
 	}
 

--- a/mime.go
+++ b/mime.go
@@ -155,7 +155,10 @@ func (m *MIME) cloneHierarchy(charset string) *MIME {
 }
 
 func (m *MIME) lookup(mime string) *MIME {
-	for _, n := range append(m.aliases, m.mime) {
+	if m.mime == mime {
+		return m
+	}
+	for _, n := range m.aliases {
 		if n == mime {
 			return m
 		}

--- a/mimetype.go
+++ b/mimetype.go
@@ -120,6 +120,8 @@ func Extend(detector func(raw []byte, limit uint32) bool, mime, extension string
 // Lookup finds a MIME object by its string representation.
 // The representation can be the main mime type, or any of its aliases.
 func Lookup(mime string) *MIME {
+	// TODO: should this function call mime.ParseMediaType to strip away addition MIME parameters?
+	// Those MIME parameters can make Lookup fail because comparison is done on plain strings.
 	mu.RLock()
 	defer mu.RUnlock()
 	return root.lookup(mime)

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -130,7 +130,7 @@ a,"b`,
 	{"line ending before html", "\r\n<html>...", "text/html; charset=utf-8", none},
 	{
 		"html with encoding",
-		`<html><head><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">`,
+		`<html><head><Meta Http-Equiv="Content-Type" content="text/html; Charset=iso-8859-1">`,
 		"text/html; charset=iso-8859-1",
 		none,
 	},


### PR DESCRIPTION
xhtml: reduce search from 4096 to 1024


markup: return byte slice instead of strings
Two reasons:
1. Previously, a to_lower copy of the original was created and returned.
This was bad because: HTML is case insensitive and XML is case sensitive.
The to_lower mutation made it impossible to work correctly for both HTML and XML.
2. Returning a byte slice from the original input means less allocation

This commit also alters the input data for HTML tests so it checks for
case insensitivity.