### PR TITLE
markup: both case sensitive and insensitive checks

### DIFF
--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -144,19 +144,13 @@ func fromXML(s scan.Bytes) string {
 	xml := []byte("<?XML")
 	lxml := len(xml)
 	for {
-		if len(s) == 0 {
-			return ""
-		}
-		for scan.ByteIsWS(s.Peek()) {
-			s.Advance(1)
-		}
+		s.TrimLWS()
 		if len(s) <= lxml {
 			return ""
 		}
-		if s.Match(xml, scan.IgnoreCase) == -1 {
-			s = s[1:] // safe to slice instead of s.Advance(1) because bounds are checked
-			continue
-		}
+
+		i, k := s.Search(xml, scan.IgnoreCase)
+		s.Advance(i + k)
 		aName, aVal, hasMore := "", "", true
 		for hasMore {
 			aName, aVal, hasMore = markup.GetAnAttribute(&s)

--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -2,6 +2,7 @@ package charset
 
 import (
 	"bytes"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/gabriel-vasile/mimetype/internal/markup"
@@ -151,11 +152,12 @@ func fromXML(s scan.Bytes) string {
 
 		i, k := s.Search(xml, scan.IgnoreCase)
 		s.Advance(i + k)
-		aName, aVal, hasMore := "", "", true
+		var aName, aVal []byte
+		hasMore := true
 		for hasMore {
 			aName, aVal, hasMore = markup.GetAnAttribute(&s)
-			if aName == "encoding" && aVal != "" {
-				return aVal
+			if scan.Bytes(aName).Match([]byte("encoding"), scan.IgnoreCase) != -1 && len(aVal) != 0 {
+				return string(aVal)
 			}
 		}
 	}
@@ -209,14 +211,16 @@ func fromHTML(s scan.Bytes) string {
 		needPragma := dontKnow
 
 		charset := ""
-		aName, aVal, hasMore := "", "", true
+		var aNameB, aValB []byte
+		hasMore := true
 		for hasMore {
-			aName, aVal, hasMore = markup.GetAnAttribute(&s)
+			aNameB, aValB, hasMore = markup.GetAnAttribute(&s)
+			aName := strings.ToLower(string(aNameB))
 			if attrList[aName] {
 				continue
 			}
 			// processing step
-			if len(aName) == 0 && len(aVal) == 0 {
+			if len(aName) == 0 && len(aValB) == 0 {
 				if needPragma == dontKnow {
 					continue
 				}
@@ -227,16 +231,16 @@ func fromHTML(s scan.Bytes) string {
 			attrList[aName] = true
 			switch aName {
 			case "http-equiv":
-				if scan.Bytes(aVal).Match([]byte("CONTENT-TYPE"), scan.IgnoreCase) != -1 {
+				if scan.Bytes(aValB).Match([]byte("CONTENT-TYPE"), scan.IgnoreCase) != -1 {
 					gotPragma = true
 				}
 			case "content":
-				charset = string(extractCharsetFromMeta(scan.Bytes(aVal)))
+				charset = string(extractCharsetFromMeta(scan.Bytes(aValB)))
 				if len(charset) != 0 {
 					needPragma = doNeedPragma
 				}
 			case "charset":
-				charset = aVal
+				charset = string(aValB)
 				needPragma = doNotNeedPragma
 			}
 		}

--- a/internal/charset/charset.go
+++ b/internal/charset/charset.go
@@ -142,7 +142,7 @@ func FromXML(content []byte) string {
 	return FromPlain(content)
 }
 func fromXML(s scan.Bytes) string {
-	xml := []byte("<?XML")
+	xml := []byte("<?xml")
 	lxml := len(xml)
 	for {
 		s.TrimLWS()
@@ -150,13 +150,16 @@ func fromXML(s scan.Bytes) string {
 			return ""
 		}
 
-		i, k := s.Search(xml, scan.IgnoreCase)
+		i, k := s.Search(xml, 0)
+		if i == -1 {
+			return ""
+		}
 		s.Advance(i + k)
 		var aName, aVal []byte
 		hasMore := true
 		for hasMore {
 			aName, aVal, hasMore = markup.GetAnAttribute(&s)
-			if scan.Bytes(aName).Match([]byte("encoding"), scan.IgnoreCase) != -1 && len(aVal) != 0 {
+			if scan.Bytes(aName).Match([]byte("encoding"), 0) != -1 && len(aVal) != 0 {
 				return string(aVal)
 			}
 		}

--- a/internal/charset/charset_test.go
+++ b/internal/charset/charset_test.go
@@ -118,6 +118,10 @@ var fromXMLTestCases = []struct {
 }, {
 	"xml at end and encoding=c <?xml encoding=c ", "c",
 }, {
+	"xml is case sensitive <?XML encoding=c ", "",
+}, {
+	"encoding is case sensitive too <?xml Encoding=c ", "",
+}, {
 	`<?xml version="1.0" encoding=c ?>`, "c",
 }, {
 	`<?xml version="1.0" encoding="c"?>`, "c",

--- a/internal/charset/charset_test.go
+++ b/internal/charset/charset_test.go
@@ -110,6 +110,14 @@ var fromXMLTestCases = []struct {
 }, {
 	"   not <?xml start ", "",
 }, {
+	"xml at end <?xml", "",
+}, {
+	"xml at end and encoding <?xml encoding", "",
+}, {
+	"xml at end and encoding= <?xml encoding=", "",
+}, {
+	"xml at end and encoding=c <?xml encoding=c ", "c",
+}, {
 	`<?xml version="1.0" encoding=c ?>`, "c",
 }, {
 	`<?xml version="1.0" encoding="c"?>`, "c",

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -209,7 +209,7 @@ func Text(raw []byte, _ uint32) bool {
 
 // XHTML matches an XHTML file. This check depends on the XML check to have passed.
 func XHTML(raw []byte, limit uint32) bool {
-	raw = raw[:min(len(raw), 4096)]
+	raw = raw[:min(len(raw), 1024)]
 	b := scan.Bytes(raw)
 	i, _ := b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase)
 	if i != -1 {

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -324,11 +324,12 @@ func svgWithoutXMLDeclaration(s scan.Bytes) bool {
 		return false
 	}
 
-	targetName, targetVal := "xmlns", "http://www.w3.org/2000/svg"
-	aName, aVal, hasMore := "", "", true
+	targetName, targetVal := []byte("xmlns"), []byte("http://www.w3.org/2000/svg")
+	var aName, aVal []byte
+	hasMore := true
 	for hasMore {
 		aName, aVal, hasMore = mkup.GetAnAttribute(&s)
-		if aName == targetName && aVal == targetVal {
+		if bytes.Equal(aName, targetName) && bytes.Equal(aVal, targetVal) {
 			return true
 		}
 		if !hasMore {
@@ -355,10 +356,11 @@ func svgWithXMLDeclaration(s scan.Bytes) bool {
 
 	// version is a required attribute for XML.
 	hasVersion := false
-	aName, hasMore := "", true
+	var aName []byte
+	hasMore := true
 	for hasMore {
 		aName, _, hasMore = mkup.GetAnAttribute(&s)
-		if aName == "version" {
+		if bytes.Equal(aName, []byte("version")) {
 			hasVersion = true
 			break
 		}

--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -8,46 +8,50 @@ import (
 	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
 
-func GetAnAttribute(s *scan.Bytes) (name, val string, hasMore bool) {
+// GetAnAttribute assumes we passed over an SGML tag and extracts first
+// attribute and its value.
+//
+// Initially, this code existed inside charset/charset.go, because it was part of
+// implementing the https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+// algorithm. But because extracting an attribute from a tag is the same for
+// both HTML and XML, then the code was moved here.
+func GetAnAttribute(s *scan.Bytes) (name, val []byte, hasMore bool) {
 	for scan.ByteIsWS(s.Peek()) || s.Peek() == '/' {
 		s.Advance(1)
 	}
 	if s.Peek() == '>' {
-		return "", "", false
+		return nil, nil, false
 	}
-	// Allocate 10 to avoid resizes.
-	// Attribute names and values are continuous slices of bytes in input,
-	// so we could do without allocating and returning slices of input.
-	nameB := make([]byte, 0, 10)
+	origS, end := *s, 0
 	// step 4 and 5
 	for {
 		// bap means byte at position in the specification.
 		bap := s.Pop()
 		if bap == 0 {
-			return "", "", false
+			return nil, nil, false
 		}
-		if bap == '=' && len(nameB) > 0 {
+		if bap == '=' && end > 0 {
 			val, hasMore := getAValue(s)
-			return string(nameB), string(val), hasMore
+			return origS[:end], val, hasMore
 		} else if scan.ByteIsWS(bap) {
 			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			if s.Peek() != '=' {
-				return string(nameB), "", true
+				return origS[:end], nil, true
 			}
 			s.Advance(1)
 			for scan.ByteIsWS(s.Peek()) {
 				s.Advance(1)
 			}
 			val, hasMore := getAValue(s)
-			return string(nameB), string(val), hasMore
+			return origS[:end], val, hasMore
 		} else if bap == '/' || bap == '>' {
-			return string(nameB), "", false
+			return origS[:end], nil, false
 		} else if bap >= 'A' && bap <= 'Z' {
-			nameB = append(nameB, bap+0x20)
+			end++
 		} else {
-			nameB = append(nameB, bap)
+			end++
 		}
 	}
 }

--- a/internal/markup/markup_test.go
+++ b/internal/markup/markup_test.go
@@ -23,7 +23,7 @@ var getAnAttributeTestCases = []struct {
 }, {
 	"1>", "1", "", false,
 }, {
-	"A>", "a", "", false,
+	"A>", "A", "", false,
 }, {
 	"a>", "a", "", false,
 }, {
@@ -47,6 +47,8 @@ var getAnAttributeTestCases = []struct {
 	" meta6 =' meta '>", "meta6", " meta ", false,
 }, {
 	` meta7 =' "meta '>`, "meta7", ` "meta `, false,
+}, {
+	` mEtA7 =' "meta '>`, "mEtA7", ` "meta `, false,
 	// / as attribute ender
 }, {
 	// when the value is unquoted / right after is a parse warning
@@ -213,10 +215,10 @@ func TestGetAllAttributes(t *testing.T) {
 		ret := [][2]string{}
 		for {
 			name, value, _ := GetAnAttribute(&s)
-			if name == "" {
+			if len(name) == 0 {
 				return ret
 			}
-			ret = append(ret, [2]string{name, value})
+			ret = append(ret, [2]string{string(name), string(value)})
 		}
 	}
 

--- a/internal/scan/bytes.go
+++ b/internal/scan/bytes.go
@@ -141,8 +141,13 @@ func (b *Bytes) Uint16() (uint16, bool) {
 type Flags int
 
 const (
+	// CompactWS will make one whitespace from pattern to match one or more spaces from input.
 	CompactWS Flags = 1 << iota
+	// IgnoreCase will match lower case from pattern with lower case from input.
+	// IgnoreCase will match upper case from pattern with both lower and upper case from input.
+	// This flag is not really well named,
 	IgnoreCase
+	// FullWord ensures the input ends with a full word (it's followed by spaces.)
 	FullWord
 )
 

--- a/internal/scan/bytes_test.go
+++ b/internal/scan/bytes_test.go
@@ -480,19 +480,14 @@ func BenchmarkMatch(b *testing.B) {
 	if _, err := io.ReadFull(r, randData); err != io.ErrUnexpectedEOF && err != nil {
 		b.Fatal(err)
 	}
-	// Benchmark all possible permutations of flags.
+	b.ReportAllocs()
 	for _, f := range []Flags{
 		0,
 		CompactWS,
 		IgnoreCase,
 		FullWord,
-		CompactWS | IgnoreCase,
-		IgnoreCase | FullWord,
-		CompactWS | FullWord,
-		CompactWS | IgnoreCase | FullWord,
 	} {
 		b.Run(fmt.Sprintf("%d", f), func(b *testing.B) {
-			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				Bytes(randData).Match(randData, f)
 			}

--- a/mime.go
+++ b/mime.go
@@ -155,7 +155,10 @@ func (m *MIME) cloneHierarchy(charset string) *MIME {
 }
 
 func (m *MIME) lookup(mime string) *MIME {
-	for _, n := range append(m.aliases, m.mime) {
+	if mime == m.mime {
+		return m
+	}
+	for _, n := range m.aliases {
 		if n == mime {
 			return m
 		}

--- a/mimetype.go
+++ b/mimetype.go
@@ -112,15 +112,18 @@ func SetLimit(limit uint32) {
 }
 
 // Extend adds detection for other file formats.
-// It is equivalent to calling Extend() on the root mime type "application/octet-stream".
+// It is equivalent to calling Extend() on the root MIME type "application/octet-stream".
 func Extend(detector func(raw []byte, limit uint32) bool, mime, extension string, aliases ...string) {
 	root.Extend(detector, mime, extension, aliases...)
 }
 
 // Lookup finds a MIME object by its string representation.
-// The representation can be the main mime type, or any of its aliases.
-func Lookup(mime string) *MIME {
+// The representation can be the main MIME type, or any of its aliases.
+func Lookup(m string) *MIME {
+	// We store the MIME types without optional params, so
+	// perform parsing to extract the target MIME type without optional params.
+	m, _, _ = mime.ParseMediaType(m)
 	mu.RLock()
 	defer mu.RUnlock()
-	return root.lookup(mime)
+	return root.lookup(m)
 }

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -130,7 +130,7 @@ a,"b`,
 	{"line ending before html", "\r\n<html>...", "text/html; charset=utf-8", none},
 	{
 		"html with encoding",
-		`<html><head><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">`,
+		`<Html><Head><metA Http-EquiV="Content-Type" Content="text/html; charset=iso-8859-1">`,
 		"text/html; charset=iso-8859-1",
 		none,
 	},


### PR DESCRIPTION
Fix charset: skip over <?xml part before looking for attributes
Previously, only the existence of <?xml was checked. Afterwards it
checks, but also skips over it when found.

Fix markup: return byte slice instead of strings
Two reasons:
1. Previously, a to_lower copy of the original was created and returned.
This was bad because: HTML is case insensitive and XML is case sensitive.
The to_lower mutation made it impossible to work correctly for both HTML and XML.
2. Returning a byte slice from the original input means less allocation

This commit also alters the input data for HTML tests so it checks for
case insensitivity.

xml: make parsing case sensitive
xhtml: reduce search from 4096 to 1024
    In benchmarks xhtml is taking some 30% of detection time. 4096 was used
    initially because that's what file limits itself to.
   
lookup: prevent allocs by not creating slices
lookup: make it more permissive
Previously, target MIME type was compared as it is with our stored MIME
types. But because all our stored MIME types are without optional
parameters, it's better to extract those params from target MIME before
looking it up.

scan: don't benchmark each possible Match flag combination
It's too many combinations and hard to follow. Individual benchmarks
suffice, I think.