### PR TITLE
markup: fix for duplicate branch warning from linter

### DIFF
--- a/internal/markup/markup.go
+++ b/internal/markup/markup.go
@@ -48,9 +48,7 @@ func GetAnAttribute(s *scan.Bytes) (name, val []byte, hasMore bool) {
 			return origS[:end], val, hasMore
 		} else if bap == '/' || bap == '>' {
 			return origS[:end], nil, false
-		} else if bap >= 'A' && bap <= 'Z' {
-			end++
-		} else {
+		} else { // for any ASCII, non-ASCII, just advance
 			end++
 		}
 	}


### PR DESCRIPTION
After some refactor, the duplicate branch came up and I didn't think it would trigger a security warning.
https://github.com/gabriel-vasile/mimetype/security/code-scanning/3