### PR TITLE
clone: stop cloning MIME when there is no charset

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -109,7 +109,7 @@ func (m *MIME) match(in []byte, readLimit uint32) *MIME {
 		// Limit the number of bytes searched for to 1024.
 		charset = f(in[:min(len(in), 1024)])
 	}
-	if m == root {
+	if m == root || charset == "" {
 		return m
 	}
 

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -606,6 +606,27 @@ func BenchmarkAll(b *testing.B) {
 	}
 }
 
+func BenchmarkAllTogether(b *testing.B) {
+	r := rand.New(rand.NewSource(0))
+	// randData is used for the negative case benchmark.
+	randData := make([]byte, defaultLimit)
+	if _, err := io.ReadFull(r, randData); err != io.ErrUnexpectedEOF && err != nil {
+		b.Fatal(err)
+	}
+	datas := [][]byte{}
+	for _, tc := range testcases {
+		datas = append(datas, []byte(tc.data))
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		for _, d := range datas {
+			Detect(d)
+			Detect(randData)
+		}
+	}
+}
+
 // Check there are no panics for nil inputs and for truncated inputs.
 func TestIndexOutOfRangePanic(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
The reason why cloning was done: for results where we include the charset, the charset was detected after MIME detection. As such, the same MIME has to be used for several charsets, ex: text/plain; charset=utf8
text/plain; charset=utf-16be

But this cloning means:
1. allocation of MIME structs for each detection
2. MIME structs received from Lookup() are originals MIME structs received from Detect() are clones Calling Extend() on originals works. On clones it does nothing.

Because of this, I'm thinking cloning was a mistake and for MIMEs that need the charset too, they should be separated MIMEs instead. In future, I plan to remove cloning for charsetted MIMEs too.

Additionally, this commit adds a benchmark that runs on all testcase files at once. It highlights the amount of allocations triggered by clones:

➜  mimetype git:(master) ✗ go test -bench=AllTogether before this commit:
BenchmarkAllTogether-8   	     968	   1219516 ns/op	   60863 B/op	     654 allocs/op
after:
BenchmarkAllTogether-8   	    1033	   1172227 ns/op	    4586 B/op	      68 allocs/op