### PR TITLE
Prevent repeated parsing for JSON

### DIFF
--- a/example_mimetype_test.go
+++ b/example_mimetype_test.go
@@ -61,7 +61,7 @@ func Example_whitelist() {
 // https://github.com/file/file/tree/master/magic/Magdir
 // have signatures for a multitude of file formats.
 func Example_extend() {
-	foobarDetector := func(f *File) bool {
+	foobarDetector := func(raw []byte, limit uint32) bool {
 		return bytes.HasPrefix(raw, []byte("foobar"))
 	}
 

--- a/example_mimetype_test.go
+++ b/example_mimetype_test.go
@@ -61,7 +61,7 @@ func Example_whitelist() {
 // https://github.com/file/file/tree/master/magic/Magdir
 // have signatures for a multitude of file formats.
 func Example_extend() {
-	foobarDetector := func(raw []byte, limit uint32) bool {
+	foobarDetector := func(f *File) bool {
 		return bytes.HasPrefix(raw, []byte("foobar"))
 	}
 

--- a/internal/magic/archive.go
+++ b/internal/magic/archive.go
@@ -7,17 +7,17 @@ import (
 
 // SevenZ matches a 7z archive.
 func SevenZ(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C})
+	return bytes.HasPrefix(f.Head, []byte{0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C})
 }
 
 // Gzip matches gzip files based on http://www.zlib.org/rfc-gzip.html#header-trailer.
 func Gzip(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x1f, 0x8b})
+	return bytes.HasPrefix(f.Head, []byte{0x1f, 0x8b})
 }
 
 // Fits matches an Flexible Image Transport System file.
 func Fits(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{
+	return bytes.HasPrefix(f.Head, []byte{
 		0x53, 0x49, 0x4D, 0x50, 0x4C, 0x45, 0x20, 0x20, 0x3D, 0x20,
 		0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
 		0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x54,
@@ -26,22 +26,22 @@ func Fits(f *File) bool {
 
 // Xar matches an eXtensible ARchive format file.
 func Xar(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x78, 0x61, 0x72, 0x21})
+	return bytes.HasPrefix(f.Head, []byte{0x78, 0x61, 0x72, 0x21})
 }
 
 // Bz2 matches a bzip2 file.
 func Bz2(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x42, 0x5A, 0x68})
+	return bytes.HasPrefix(f.Head, []byte{0x42, 0x5A, 0x68})
 }
 
 // Ar matches an ar (Unix) archive file.
 func Ar(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x21, 0x3C, 0x61, 0x72, 0x63, 0x68, 0x3E})
+	return bytes.HasPrefix(f.Head, []byte{0x21, 0x3C, 0x61, 0x72, 0x63, 0x68, 0x3E})
 }
 
 // Deb matches a Debian package file.
 func Deb(f *File) bool {
-	return offset(raw, []byte{
+	return offset(f.Head, []byte{
 		0x64, 0x65, 0x62, 0x69, 0x61, 0x6E, 0x2D,
 		0x62, 0x69, 0x6E, 0x61, 0x72, 0x79,
 	}, 8)
@@ -49,52 +49,52 @@ func Deb(f *File) bool {
 
 // Warc matches a Web ARChive file.
 func Warc(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("WARC/1.0")) ||
-		bytes.HasPrefix(raw, []byte("WARC/1.1"))
+	return bytes.HasPrefix(f.Head, []byte("WARC/1.0")) ||
+		bytes.HasPrefix(f.Head, []byte("WARC/1.1"))
 }
 
 // Cab matches a Microsoft Cabinet archive file.
 func Cab(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("MSCF\x00\x00\x00\x00"))
+	return bytes.HasPrefix(f.Head, []byte("MSCF\x00\x00\x00\x00"))
 }
 
 // Xz matches an xz compressed stream based on https://tukaani.org/xz/xz-file-format.txt.
 func Xz(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00})
+	return bytes.HasPrefix(f.Head, []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00})
 }
 
 // Lzip matches an Lzip compressed file.
 func Lzip(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x4c, 0x5a, 0x49, 0x50})
+	return bytes.HasPrefix(f.Head, []byte{0x4c, 0x5a, 0x49, 0x50})
 }
 
 // RPM matches an RPM or Delta RPM package file.
 func RPM(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0xed, 0xab, 0xee, 0xdb}) ||
-		bytes.HasPrefix(raw, []byte("drpm"))
+	return bytes.HasPrefix(f.Head, []byte{0xed, 0xab, 0xee, 0xdb}) ||
+		bytes.HasPrefix(f.Head, []byte("drpm"))
 }
 
 // RAR matches a RAR archive file.
 func RAR(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("Rar!\x1A\x07\x00")) ||
-		bytes.HasPrefix(raw, []byte("Rar!\x1A\x07\x01\x00"))
+	return bytes.HasPrefix(f.Head, []byte("Rar!\x1A\x07\x00")) ||
+		bytes.HasPrefix(f.Head, []byte("Rar!\x1A\x07\x01\x00"))
 }
 
 // InstallShieldCab matches an InstallShield Cabinet archive file.
 func InstallShieldCab(f *File) bool {
-	return len(raw) > 7 &&
-		bytes.Equal(raw[0:4], []byte("ISc(")) &&
-		raw[6] == 0 &&
-		(raw[7] == 1 || raw[7] == 2 || raw[7] == 4)
+	return len(f.Head) > 7 &&
+		bytes.Equal(f.Head[0:4], []byte("ISc(")) &&
+		f.Head[6] == 0 &&
+		(f.Head[7] == 1 || f.Head[7] == 2 || f.Head[7] == 4)
 }
 
 // Zstd matches a Zstandard archive file.
 // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md
 func Zstd(f *File) bool {
-	if len(raw) < 4 {
+	if len(f.Head) < 4 {
 		return false
 	}
-	sig := binary.LittleEndian.Uint32(raw)
+	sig := binary.LittleEndian.Uint32(f.Head)
 	// Check for Zstandard frames and skippable frames.
 	return (sig >= 0xFD2FB522 && sig <= 0xFD2FB528) ||
 		(sig >= 0x184D2A50 && sig <= 0x184D2A5F)
@@ -103,33 +103,34 @@ func Zstd(f *File) bool {
 // CRX matches a Chrome extension file: a zip archive prepended by a package header.
 func CRX(f *File) bool {
 	const minHeaderLen = 16
-	if len(raw) < minHeaderLen || !bytes.HasPrefix(raw, []byte("Cr24")) {
+	if len(f.Head) < minHeaderLen || !bytes.HasPrefix(f.Head, []byte("Cr24")) {
 		return false
 	}
-	pubkeyLen := binary.LittleEndian.Uint32(raw[8:12])
-	sigLen := binary.LittleEndian.Uint32(raw[12:16])
+	pubkeyLen := binary.LittleEndian.Uint32(f.Head[8:12])
+	sigLen := binary.LittleEndian.Uint32(f.Head[12:16])
 	zipOffset := minHeaderLen + pubkeyLen + sigLen
-	if uint32(len(raw)) < zipOffset {
+	if uint32(len(f.Head)) < zipOffset {
 		return false
 	}
-	return Zip(raw[zipOffset:], limit)
+	return Zip(&File{Head: f.Head[zipOffset:], ReadLimit: f.ReadLimit})
 }
 
 // Cpio matches a cpio archive file.
 func Cpio(f *File) bool {
-	if len(raw) < 6 {
+	if len(f.Head) < 6 {
 		return false
 	}
-	return binary.LittleEndian.Uint16(raw) == 070707 || // binary cpio
-		bytes.HasPrefix(raw, []byte("070707")) || // portable ASCII cpios
-		bytes.HasPrefix(raw, []byte("070701")) ||
-		bytes.HasPrefix(raw, []byte("070702"))
+	return binary.LittleEndian.Uint16(f.Head) == 070707 || // binary cpio
+		bytes.HasPrefix(f.Head, []byte("070707")) || // portable ASCII cpios
+		bytes.HasPrefix(f.Head, []byte("070701")) ||
+		bytes.HasPrefix(f.Head, []byte("070702"))
 }
 
 // Tar matches a (t)ape (ar)chive file.
 // Tar files are divided into 512 bytes records. First record contains a 257
 // bytes header padded with NUL.
 func Tar(f *File) bool {
+	head := f.Head
 	const sizeRecord = 512
 
 	// The structure of a tar header:
@@ -150,23 +151,23 @@ func Tar(f *File) bool {
 	// 	Devminor [8]byte
 	// }
 
-	if len(raw) < sizeRecord {
+	if len(head) < sizeRecord {
 		return false
 	}
-	raw = raw[:sizeRecord]
+	head = head[:sizeRecord]
 
 	// First 100 bytes of the header represent the file name.
 	// Check if file looks like Gentoo GLEP binary package.
-	if bytes.Contains(raw[:100], []byte("/gpkg-1\x00")) {
+	if bytes.Contains(head[:100], []byte("/gpkg-1\x00")) {
 		return false
 	}
 
 	// Get the checksum recorded into the file.
-	recsum := tarParseOctal(raw[148:156])
+	recsum := tarParseOctal(head[148:156])
 	if recsum == -1 {
 		return false
 	}
-	sum1, sum2 := tarChksum(raw)
+	sum1, sum2 := tarChksum(head)
 	return recsum == sum1 || recsum == sum2
 }
 

--- a/internal/magic/audio.go
+++ b/internal/magic/audio.go
@@ -7,63 +7,63 @@ import (
 
 // Flac matches a Free Lossless Audio Codec file.
 func Flac(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
+	return bytes.HasPrefix(f.Head, []byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
 }
 
 // Midi matches a Musical Instrument Digital Interface file.
 func Midi(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x4D\x54\x68\x64"))
+	return bytes.HasPrefix(f.Head, []byte("\x4D\x54\x68\x64"))
 }
 
 // Ape matches a Monkey's Audio file.
 func Ape(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x4D\x41\x43\x20\x96\x0F\x00\x00\x34\x00\x00\x00\x18\x00\x00\x00\x90\xE3"))
+	return bytes.HasPrefix(f.Head, []byte("\x4D\x41\x43\x20\x96\x0F\x00\x00\x34\x00\x00\x00\x18\x00\x00\x00\x90\xE3"))
 }
 
 // MusePack matches a Musepack file.
 func MusePack(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("MPCK"))
+	return bytes.HasPrefix(f.Head, []byte("MPCK"))
 }
 
 // Au matches a Sun Microsystems au file.
 func Au(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x2E\x73\x6E\x64"))
+	return bytes.HasPrefix(f.Head, []byte("\x2E\x73\x6E\x64"))
 }
 
 // Amr matches an Adaptive Multi-Rate file.
 func Amr(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x23\x21\x41\x4D\x52"))
+	return bytes.HasPrefix(f.Head, []byte("\x23\x21\x41\x4D\x52"))
 }
 
 // Voc matches a Creative Voice file.
 func Voc(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("Creative Voice File"))
+	return bytes.HasPrefix(f.Head, []byte("Creative Voice File"))
 }
 
 // M3u matches a Playlist file.
 func M3u(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("#EXTM3U"))
+	return bytes.HasPrefix(f.Head, []byte("#EXTM3U"))
 }
 
 // AAC matches an Advanced Audio Coding file.
 func AAC(f *File) bool {
-	return len(raw) > 1 && ((raw[0] == 0xFF && raw[1] == 0xF1) || (raw[0] == 0xFF && raw[1] == 0xF9))
+	return len(f.Head) > 1 && ((f.Head[0] == 0xFF && f.Head[1] == 0xF1) || (f.Head[0] == 0xFF && f.Head[1] == 0xF9))
 }
 
 // Mp3 matches an mp3 file.
 func Mp3(f *File) bool {
-	if len(raw) < 3 {
+	if len(f.Head) < 3 {
 		return false
 	}
 
-	if bytes.HasPrefix(raw, []byte("ID3")) {
+	if bytes.HasPrefix(f.Head, []byte("ID3")) {
 		// MP3s with an ID3v2 tag will start with "ID3"
 		// ID3v1 tags, however appear at the end of the file.
 		return true
 	}
 
 	// Match MP3 files without tags
-	switch binary.BigEndian.Uint16(raw[:2]) & 0xFFFE {
+	switch binary.BigEndian.Uint16(f.Head[:2]) & 0xFFFE {
 	case 0xFFFA:
 		// MPEG ADTS, layer III, v1
 		return true
@@ -80,21 +80,21 @@ func Mp3(f *File) bool {
 
 // Wav matches a Waveform Audio File Format file.
 func Wav(f *File) bool {
-	return len(raw) > 12 &&
-		bytes.Equal(raw[:4], []byte("RIFF")) &&
-		bytes.Equal(raw[8:12], []byte{0x57, 0x41, 0x56, 0x45})
+	return len(f.Head) > 12 &&
+		bytes.Equal(f.Head[:4], []byte("RIFF")) &&
+		bytes.Equal(f.Head[8:12], []byte{0x57, 0x41, 0x56, 0x45})
 }
 
 // Aiff matches Audio Interchange File Format file.
 func Aiff(f *File) bool {
-	return len(raw) > 12 &&
-		bytes.Equal(raw[:4], []byte{0x46, 0x4F, 0x52, 0x4D}) &&
-		bytes.Equal(raw[8:12], []byte{0x41, 0x49, 0x46, 0x46})
+	return len(f.Head) > 12 &&
+		bytes.Equal(f.Head[:4], []byte{0x46, 0x4F, 0x52, 0x4D}) &&
+		bytes.Equal(f.Head[8:12], []byte{0x41, 0x49, 0x46, 0x46})
 }
 
 // Qcp matches a Qualcomm Pure Voice file.
 func Qcp(f *File) bool {
-	return len(raw) > 12 &&
-		bytes.Equal(raw[:4], []byte("RIFF")) &&
-		bytes.Equal(raw[8:12], []byte("QLCM"))
+	return len(f.Head) > 12 &&
+		bytes.Equal(f.Head[:4], []byte("RIFF")) &&
+		bytes.Equal(f.Head[8:12], []byte("QLCM"))
 }

--- a/internal/magic/audio.go
+++ b/internal/magic/audio.go
@@ -6,52 +6,52 @@ import (
 )
 
 // Flac matches a Free Lossless Audio Codec file.
-func Flac(raw []byte, _ uint32) bool {
+func Flac(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
 }
 
 // Midi matches a Musical Instrument Digital Interface file.
-func Midi(raw []byte, _ uint32) bool {
+func Midi(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x4D\x54\x68\x64"))
 }
 
 // Ape matches a Monkey's Audio file.
-func Ape(raw []byte, _ uint32) bool {
+func Ape(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x4D\x41\x43\x20\x96\x0F\x00\x00\x34\x00\x00\x00\x18\x00\x00\x00\x90\xE3"))
 }
 
 // MusePack matches a Musepack file.
-func MusePack(raw []byte, _ uint32) bool {
+func MusePack(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("MPCK"))
 }
 
 // Au matches a Sun Microsystems au file.
-func Au(raw []byte, _ uint32) bool {
+func Au(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x2E\x73\x6E\x64"))
 }
 
 // Amr matches an Adaptive Multi-Rate file.
-func Amr(raw []byte, _ uint32) bool {
+func Amr(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x23\x21\x41\x4D\x52"))
 }
 
 // Voc matches a Creative Voice file.
-func Voc(raw []byte, _ uint32) bool {
+func Voc(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("Creative Voice File"))
 }
 
 // M3u matches a Playlist file.
-func M3u(raw []byte, _ uint32) bool {
+func M3u(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("#EXTM3U"))
 }
 
 // AAC matches an Advanced Audio Coding file.
-func AAC(raw []byte, _ uint32) bool {
+func AAC(f *File) bool {
 	return len(raw) > 1 && ((raw[0] == 0xFF && raw[1] == 0xF1) || (raw[0] == 0xFF && raw[1] == 0xF9))
 }
 
 // Mp3 matches an mp3 file.
-func Mp3(raw []byte, limit uint32) bool {
+func Mp3(f *File) bool {
 	if len(raw) < 3 {
 		return false
 	}
@@ -79,21 +79,21 @@ func Mp3(raw []byte, limit uint32) bool {
 }
 
 // Wav matches a Waveform Audio File Format file.
-func Wav(raw []byte, limit uint32) bool {
+func Wav(f *File) bool {
 	return len(raw) > 12 &&
 		bytes.Equal(raw[:4], []byte("RIFF")) &&
 		bytes.Equal(raw[8:12], []byte{0x57, 0x41, 0x56, 0x45})
 }
 
 // Aiff matches Audio Interchange File Format file.
-func Aiff(raw []byte, limit uint32) bool {
+func Aiff(f *File) bool {
 	return len(raw) > 12 &&
 		bytes.Equal(raw[:4], []byte{0x46, 0x4F, 0x52, 0x4D}) &&
 		bytes.Equal(raw[8:12], []byte{0x41, 0x49, 0x46, 0x46})
 }
 
 // Qcp matches a Qualcomm Pure Voice file.
-func Qcp(raw []byte, limit uint32) bool {
+func Qcp(f *File) bool {
 	return len(raw) > 12 &&
 		bytes.Equal(raw[:4], []byte("RIFF")) &&
 		bytes.Equal(raw[8:12], []byte("QLCM"))

--- a/internal/magic/binary.go
+++ b/internal/magic/binary.go
@@ -7,49 +7,49 @@ import (
 )
 
 // Lnk matches Microsoft lnk binary format.
-func Lnk(raw []byte, _ uint32) bool {
+func Lnk(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x4C, 0x00, 0x00, 0x00, 0x01, 0x14, 0x02, 0x00})
 }
 
 // Wasm matches a web assembly File Format file.
-func Wasm(raw []byte, _ uint32) bool {
+func Wasm(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x00, 0x61, 0x73, 0x6D})
 }
 
 // Exe matches a Windows/DOS executable file.
-func Exe(raw []byte, _ uint32) bool {
+func Exe(f *File) bool {
 	return len(raw) > 1 && raw[0] == 0x4D && raw[1] == 0x5A
 }
 
 // Elf matches an Executable and Linkable Format file.
-func Elf(raw []byte, _ uint32) bool {
+func Elf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x7F, 0x45, 0x4C, 0x46})
 }
 
 // Nes matches a Nintendo Entertainment system ROM file.
-func Nes(raw []byte, _ uint32) bool {
+func Nes(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x4E, 0x45, 0x53, 0x1A})
 }
 
 // SWF matches an Adobe Flash swf file.
-func SWF(raw []byte, _ uint32) bool {
+func SWF(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("CWS")) ||
 		bytes.HasPrefix(raw, []byte("FWS")) ||
 		bytes.HasPrefix(raw, []byte("ZWS"))
 }
 
 // Torrent has bencoded text in the beginning.
-func Torrent(raw []byte, _ uint32) bool {
+func Torrent(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("d8:announce"))
 }
 
 // PAR1 matches a parquet file.
-func Par1(raw []byte, _ uint32) bool {
+func Par1(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x50, 0x41, 0x52, 0x31})
 }
 
 // CBOR matches a Concise Binary Object Representation https://cbor.io/
-func CBOR(raw []byte, _ uint32) bool {
+func CBOR(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0xD9, 0xD9, 0xF7})
 }
 
@@ -66,12 +66,12 @@ func classOrMachOFat(in []byte) bool {
 }
 
 // Class matches a java class file.
-func Class(raw []byte, limit uint32) bool {
+func Class(f *File) bool {
 	return classOrMachOFat(raw) && raw[7] > 30
 }
 
 // MachO matches Mach-O binaries format.
-func MachO(raw []byte, limit uint32) bool {
+func MachO(f *File) bool {
 	if classOrMachOFat(raw) && raw[7] < 0x14 {
 		return true
 	}
@@ -91,7 +91,7 @@ func MachO(raw []byte, limit uint32) bool {
 
 // Dbf matches a dBase file.
 // https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
-func Dbf(raw []byte, limit uint32) bool {
+func Dbf(f *File) bool {
 	if len(raw) < 68 {
 		return false
 	}
@@ -127,37 +127,37 @@ func Dbf(raw []byte, limit uint32) bool {
 }
 
 // ElfObj matches an object file.
-func ElfObj(raw []byte, limit uint32) bool {
+func ElfObj(f *File) bool {
 	return len(raw) > 17 && ((raw[16] == 0x01 && raw[17] == 0x00) ||
 		(raw[16] == 0x00 && raw[17] == 0x01))
 }
 
 // ElfExe matches an executable file.
-func ElfExe(raw []byte, limit uint32) bool {
+func ElfExe(f *File) bool {
 	return len(raw) > 17 && ((raw[16] == 0x02 && raw[17] == 0x00) ||
 		(raw[16] == 0x00 && raw[17] == 0x02))
 }
 
 // ElfLib matches a shared library file.
-func ElfLib(raw []byte, limit uint32) bool {
+func ElfLib(f *File) bool {
 	return len(raw) > 17 && ((raw[16] == 0x03 && raw[17] == 0x00) ||
 		(raw[16] == 0x00 && raw[17] == 0x03))
 }
 
 // ElfDump matches a core dump file.
-func ElfDump(raw []byte, limit uint32) bool {
+func ElfDump(f *File) bool {
 	return len(raw) > 17 && ((raw[16] == 0x04 && raw[17] == 0x00) ||
 		(raw[16] == 0x00 && raw[17] == 0x04))
 }
 
 // Dcm matches a DICOM medical format file.
-func Dcm(raw []byte, limit uint32) bool {
+func Dcm(f *File) bool {
 	return len(raw) > 131 &&
 		bytes.Equal(raw[128:132], []byte{0x44, 0x49, 0x43, 0x4D})
 }
 
 // Marc matches a MARC21 (MAchine-Readable Cataloging) file.
-func Marc(raw []byte, limit uint32) bool {
+func Marc(f *File) bool {
 	// File is at least 24 bytes ("leader" field size).
 	if len(raw) < 24 {
 		return false
@@ -194,7 +194,7 @@ func Marc(raw []byte, limit uint32) bool {
 //
 // [glTF specification]: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
 // [IANA glTF entry]: https://www.iana.org/assignments/media-types/model/gltf-binary
-func GLB(raw []byte, _ uint32) bool {
+func GLB(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x67\x6C\x54\x46\x02\x00\x00\x00")) ||
 		bytes.HasPrefix(raw, []byte("\x67\x6C\x54\x46\x01\x00\x00\x00"))
 }
@@ -211,7 +211,7 @@ func GLB(raw []byte, _ uint32) bool {
 //	|  isutccnt (4) |  isstdcnt (4) |  leapcnt  (4) |
 //	+---------------+---------------+---------------+
 //	|  timecnt  (4) |  typecnt  (4) |  charcnt  (4) |
-func TzIf(raw []byte, limit uint32) bool {
+func TzIf(f *File) bool {
 	// File is at least 44 bytes (header size).
 	if len(raw) < 44 {
 		return false

--- a/internal/magic/database.go
+++ b/internal/magic/database.go
@@ -3,7 +3,7 @@ package magic
 import "bytes"
 
 // Sqlite matches an SQLite database file.
-func Sqlite(raw []byte, _ uint32) bool {
+func Sqlite(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{
 		0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66,
 		0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00,
@@ -11,11 +11,11 @@ func Sqlite(raw []byte, _ uint32) bool {
 }
 
 // MsAccessAce matches Microsoft Access dababase file.
-func MsAccessAce(raw []byte, _ uint32) bool {
+func MsAccessAce(f *File) bool {
 	return offset(raw, []byte("Standard ACE DB"), 4)
 }
 
 // MsAccessMdb matches legacy Microsoft Access database file (JET, 2003 and earlier).
-func MsAccessMdb(raw []byte, _ uint32) bool {
+func MsAccessMdb(f *File) bool {
 	return offset(raw, []byte("Standard Jet DB"), 4)
 }

--- a/internal/magic/database.go
+++ b/internal/magic/database.go
@@ -4,7 +4,7 @@ import "bytes"
 
 // Sqlite matches an SQLite database file.
 func Sqlite(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{
+	return bytes.HasPrefix(f.Head, []byte{
 		0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66,
 		0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00,
 	})
@@ -12,10 +12,10 @@ func Sqlite(f *File) bool {
 
 // MsAccessAce matches Microsoft Access dababase file.
 func MsAccessAce(f *File) bool {
-	return offset(raw, []byte("Standard ACE DB"), 4)
+	return offset(f.Head, []byte("Standard ACE DB"), 4)
 }
 
 // MsAccessMdb matches legacy Microsoft Access database file (JET, 2003 and earlier).
 func MsAccessMdb(f *File) bool {
-	return offset(raw, []byte("Standard Jet DB"), 4)
+	return offset(f.Head, []byte("Standard Jet DB"), 4)
 }

--- a/internal/magic/document.go
+++ b/internal/magic/document.go
@@ -7,7 +7,7 @@ import (
 
 // Pdf matches a Portable Document Format file.
 // https://github.com/file/file/blob/11010cc805546a3e35597e67e1129a481aed40e8/magic/Magdir/pdf
-func Pdf(raw []byte, _ uint32) bool {
+func Pdf(f *File) bool {
 	// usual pdf signature
 	return bytes.HasPrefix(raw, []byte("%PDF-")) ||
 		// new-line prefixed signature
@@ -17,17 +17,17 @@ func Pdf(raw []byte, _ uint32) bool {
 }
 
 // Fdf matches a Forms Data Format file.
-func Fdf(raw []byte, _ uint32) bool {
+func Fdf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("%FDF"))
 }
 
 // Mobi matches a Mobi file.
-func Mobi(raw []byte, _ uint32) bool {
+func Mobi(f *File) bool {
 	return offset(raw, []byte("BOOKMOBI"), 60)
 }
 
 // Lit matches a Microsoft Lit file.
-func Lit(raw []byte, _ uint32) bool {
+func Lit(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("ITOLITLS"))
 }
 
@@ -36,13 +36,13 @@ func Lit(raw []byte, _ uint32) bool {
 // implementations don't follow the rule. The PDF spec at Appendix H says the
 // signature can be prepended by anything.
 // https://bugs.astron.com/view.php?id=446
-func PDF(raw []byte, _ uint32) bool {
+func PDF(f *File) bool {
 	raw = raw[:min(len(raw), 1024)]
 	return bytes.Contains(raw, []byte("%PDF-"))
 }
 
 // DjVu matches a DjVu file.
-func DjVu(raw []byte, _ uint32) bool {
+func DjVu(f *File) bool {
 	if len(raw) < 12 {
 		return false
 	}
@@ -56,7 +56,7 @@ func DjVu(raw []byte, _ uint32) bool {
 }
 
 // P7s matches an .p7s signature File (PEM, Base64).
-func P7s(raw []byte, _ uint32) bool {
+func P7s(f *File) bool {
 	// Check for PEM Encoding.
 	if bytes.HasPrefix(raw, []byte("-----BEGIN PKCS7")) {
 		return true
@@ -82,7 +82,7 @@ func P7s(raw []byte, _ uint32) bool {
 }
 
 // Lotus123 matches a Lotus 1-2-3 spreadsheet document.
-func Lotus123(raw []byte, _ uint32) bool {
+func Lotus123(f *File) bool {
 	if len(raw) <= 20 {
 		return false
 	}
@@ -95,6 +95,6 @@ func Lotus123(raw []byte, _ uint32) bool {
 }
 
 // CHM matches a Microsoft Compiled HTML Help file.
-func CHM(raw []byte, _ uint32) bool {
+func CHM(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("ITSF\003\000\000\000\x60\000\000\000"))
 }

--- a/internal/magic/font.go
+++ b/internal/magic/font.go
@@ -6,40 +6,40 @@ import (
 
 // Woff matches a Web Open Font Format file.
 func Woff(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("wOFF"))
+	return bytes.HasPrefix(f.Head, []byte("wOFF"))
 }
 
 // Woff2 matches a Web Open Font Format version 2 file.
 func Woff2(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("wOF2"))
+	return bytes.HasPrefix(f.Head, []byte("wOF2"))
 }
 
 // Otf matches an OpenType font file.
 func Otf(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x4F, 0x54, 0x54, 0x4F, 0x00})
+	return bytes.HasPrefix(f.Head, []byte{0x4F, 0x54, 0x54, 0x4F, 0x00})
 }
 
 // Ttf matches a TrueType font file.
 func Ttf(f *File) bool {
-	if !bytes.HasPrefix(raw, []byte{0x00, 0x01, 0x00, 0x00}) {
+	if !bytes.HasPrefix(f.Head, []byte{0x00, 0x01, 0x00, 0x00}) {
 		return false
 	}
-	return !MsAccessAce(raw, limit) && !MsAccessMdb(raw, limit)
+	return !MsAccessAce(f) && !MsAccessMdb(f)
 }
 
 // Eot matches an Embedded OpenType font file.
 func Eot(f *File) bool {
-	return len(raw) > 35 &&
-		bytes.Equal(raw[34:36], []byte{0x4C, 0x50}) &&
-		(bytes.Equal(raw[8:11], []byte{0x02, 0x00, 0x01}) ||
-			bytes.Equal(raw[8:11], []byte{0x01, 0x00, 0x00}) ||
-			bytes.Equal(raw[8:11], []byte{0x02, 0x00, 0x02}))
+	return len(f.Head) > 35 &&
+		bytes.Equal(f.Head[34:36], []byte{0x4C, 0x50}) &&
+		(bytes.Equal(f.Head[8:11], []byte{0x02, 0x00, 0x01}) ||
+			bytes.Equal(f.Head[8:11], []byte{0x01, 0x00, 0x00}) ||
+			bytes.Equal(f.Head[8:11], []byte{0x02, 0x00, 0x02}))
 }
 
 // Ttc matches a TrueType Collection font file.
 func Ttc(f *File) bool {
-	return len(raw) > 7 &&
-		bytes.HasPrefix(raw, []byte("ttcf")) &&
-		(bytes.Equal(raw[4:8], []byte{0x00, 0x01, 0x00, 0x00}) ||
-			bytes.Equal(raw[4:8], []byte{0x00, 0x02, 0x00, 0x00}))
+	return len(f.Head) > 7 &&
+		bytes.HasPrefix(f.Head, []byte("ttcf")) &&
+		(bytes.Equal(f.Head[4:8], []byte{0x00, 0x01, 0x00, 0x00}) ||
+			bytes.Equal(f.Head[4:8], []byte{0x00, 0x02, 0x00, 0x00}))
 }

--- a/internal/magic/font.go
+++ b/internal/magic/font.go
@@ -5,22 +5,22 @@ import (
 )
 
 // Woff matches a Web Open Font Format file.
-func Woff(raw []byte, _ uint32) bool {
+func Woff(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("wOFF"))
 }
 
 // Woff2 matches a Web Open Font Format version 2 file.
-func Woff2(raw []byte, _ uint32) bool {
+func Woff2(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("wOF2"))
 }
 
 // Otf matches an OpenType font file.
-func Otf(raw []byte, _ uint32) bool {
+func Otf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x4F, 0x54, 0x54, 0x4F, 0x00})
 }
 
 // Ttf matches a TrueType font file.
-func Ttf(raw []byte, limit uint32) bool {
+func Ttf(f *File) bool {
 	if !bytes.HasPrefix(raw, []byte{0x00, 0x01, 0x00, 0x00}) {
 		return false
 	}
@@ -28,7 +28,7 @@ func Ttf(raw []byte, limit uint32) bool {
 }
 
 // Eot matches an Embedded OpenType font file.
-func Eot(raw []byte, limit uint32) bool {
+func Eot(f *File) bool {
 	return len(raw) > 35 &&
 		bytes.Equal(raw[34:36], []byte{0x4C, 0x50}) &&
 		(bytes.Equal(raw[8:11], []byte{0x02, 0x00, 0x01}) ||
@@ -37,7 +37,7 @@ func Eot(raw []byte, limit uint32) bool {
 }
 
 // Ttc matches a TrueType Collection font file.
-func Ttc(raw []byte, limit uint32) bool {
+func Ttc(f *File) bool {
 	return len(raw) > 7 &&
 		bytes.HasPrefix(raw, []byte("ttcf")) &&
 		(bytes.Equal(raw[4:8], []byte{0x00, 0x01, 0x00, 0x00}) ||

--- a/internal/magic/ftyp.go
+++ b/internal/magic/ftyp.go
@@ -7,12 +7,12 @@ import (
 // AVIF matches an AV1 Image File Format still or animated.
 // Wikipedia page seems outdated listing image/avif-sequence for animations.
 // https://github.com/AOMediaCodec/av1-avif/issues/59
-func AVIF(raw []byte, _ uint32) bool {
+func AVIF(f *File) bool {
 	return ftyp(raw, []byte("avif"), []byte("avis"))
 }
 
 // ThreeGP matches a 3GPP file.
-func ThreeGP(raw []byte, _ uint32) bool {
+func ThreeGP(f *File) bool {
 	return ftyp(raw,
 		[]byte("3gp1"), []byte("3gp2"), []byte("3gp3"), []byte("3gp4"),
 		[]byte("3gp5"), []byte("3gp6"), []byte("3gp7"), []byte("3gs7"),
@@ -21,7 +21,7 @@ func ThreeGP(raw []byte, _ uint32) bool {
 }
 
 // ThreeG2 matches a 3GPP2 file.
-func ThreeG2(raw []byte, _ uint32) bool {
+func ThreeG2(f *File) bool {
 	return ftyp(raw,
 		[]byte("3g24"), []byte("3g25"), []byte("3g26"), []byte("3g2a"),
 		[]byte("3g2b"), []byte("3g2c"), []byte("KDDI"),
@@ -29,7 +29,7 @@ func ThreeG2(raw []byte, _ uint32) bool {
 }
 
 // AMp4 matches an audio MP4 file.
-func AMp4(raw []byte, _ uint32) bool {
+func AMp4(f *File) bool {
 	return ftyp(raw,
 		// audio for Adobe Flash Player 9+
 		[]byte("F4A "), []byte("F4B "),
@@ -43,49 +43,49 @@ func AMp4(raw []byte, _ uint32) bool {
 }
 
 // Mqv matches a Sony / Mobile QuickTime  file.
-func Mqv(raw []byte, _ uint32) bool {
+func Mqv(f *File) bool {
 	return ftyp(raw, []byte("mqt "))
 }
 
 // M4a matches an audio M4A file.
-func M4a(raw []byte, _ uint32) bool {
+func M4a(f *File) bool {
 	return ftyp(raw, []byte("M4A "))
 }
 
 // M4v matches an Appl4 M4V video file.
-func M4v(raw []byte, _ uint32) bool {
+func M4v(f *File) bool {
 	return ftyp(raw, []byte("M4V "), []byte("M4VH"), []byte("M4VP"))
 }
 
 // Heic matches a High Efficiency Image Coding (HEIC) file.
-func Heic(raw []byte, _ uint32) bool {
+func Heic(f *File) bool {
 	return ftyp(raw, []byte("heic"), []byte("heix"))
 }
 
 // HeicSequence matches a High Efficiency Image Coding (HEIC) file sequence.
-func HeicSequence(raw []byte, _ uint32) bool {
+func HeicSequence(f *File) bool {
 	return ftyp(raw, []byte("hevc"), []byte("hevx"))
 }
 
 // Heif matches a High Efficiency Image File Format (HEIF) file.
-func Heif(raw []byte, _ uint32) bool {
+func Heif(f *File) bool {
 	return ftyp(raw, []byte("mif1"), []byte("heim"), []byte("heis"), []byte("avic"))
 }
 
 // HeifSequence matches a High Efficiency Image File Format (HEIF) file sequence.
-func HeifSequence(raw []byte, _ uint32) bool {
+func HeifSequence(f *File) bool {
 	return ftyp(raw, []byte("msf1"), []byte("hevm"), []byte("hevs"), []byte("avcs"))
 }
 
 // Mj2 matches a Motion JPEG 2000 file: https://en.wikipedia.org/wiki/Motion_JPEG_2000.
-func Mj2(raw []byte, _ uint32) bool {
+func Mj2(f *File) bool {
 	return ftyp(raw, []byte("mj2s"), []byte("mjp2"), []byte("MFSM"), []byte("MGSV"))
 }
 
 // Dvb matches a Digital Video Broadcasting file: https://dvb.org.
 // https://cconcolato.github.io/mp4ra/filetype.html
 // https://github.com/file/file/blob/512840337ead1076519332d24fefcaa8fac36e06/magic/Magdir/animation#L135-L154
-func Dvb(raw []byte, _ uint32) bool {
+func Dvb(f *File) bool {
 	return ftyp(raw,
 		[]byte("dby1"), []byte("dsms"), []byte("dts1"), []byte("dts2"),
 		[]byte("dts3"), []byte("dxo "), []byte("dmb1"), []byte("dmpf"),
@@ -100,7 +100,7 @@ func Dvb(raw []byte, _ uint32) bool {
 // https://www.loc.gov/preservation/digital/formats/fdd/fdd000052.shtml
 // https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-38190
 // https://github.com/apache/tika/blob/0f5570691133c75ac4472c3340354a6c4080b104/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml#L7758-L7777
-func QuickTime(raw []byte, _ uint32) bool {
+func QuickTime(f *File) bool {
 	if len(raw) < 12 {
 		return false
 	}
@@ -131,7 +131,7 @@ func QuickTime(raw []byte, _ uint32) bool {
 // Mp4 has many registered and unregistered code points so it's hard to keep track
 // of all. Detection will default on video/mp4 for all ftyp files.
 // ISO_IEC_14496-12 is the specification for the iso container.
-func Mp4(raw []byte, _ uint32) bool {
+func Mp4(f *File) bool {
 	if len(raw) < 12 {
 		return false
 	}

--- a/internal/magic/ftyp.go
+++ b/internal/magic/ftyp.go
@@ -8,12 +8,12 @@ import (
 // Wikipedia page seems outdated listing image/avif-sequence for animations.
 // https://github.com/AOMediaCodec/av1-avif/issues/59
 func AVIF(f *File) bool {
-	return ftyp(raw, []byte("avif"), []byte("avis"))
+	return ftyp(f.Head, []byte("avif"), []byte("avis"))
 }
 
 // ThreeGP matches a 3GPP file.
 func ThreeGP(f *File) bool {
-	return ftyp(raw,
+	return ftyp(f.Head,
 		[]byte("3gp1"), []byte("3gp2"), []byte("3gp3"), []byte("3gp4"),
 		[]byte("3gp5"), []byte("3gp6"), []byte("3gp7"), []byte("3gs7"),
 		[]byte("3ge6"), []byte("3ge7"), []byte("3gg6"),
@@ -22,7 +22,7 @@ func ThreeGP(f *File) bool {
 
 // ThreeG2 matches a 3GPP2 file.
 func ThreeG2(f *File) bool {
-	return ftyp(raw,
+	return ftyp(f.Head,
 		[]byte("3g24"), []byte("3g25"), []byte("3g26"), []byte("3g2a"),
 		[]byte("3g2b"), []byte("3g2c"), []byte("KDDI"),
 	)
@@ -30,7 +30,7 @@ func ThreeG2(f *File) bool {
 
 // AMp4 matches an audio MP4 file.
 func AMp4(f *File) bool {
-	return ftyp(raw,
+	return ftyp(f.Head,
 		// audio for Adobe Flash Player 9+
 		[]byte("F4A "), []byte("F4B "),
 		// Apple iTunes AAC-LC (.M4A) Audio
@@ -44,49 +44,49 @@ func AMp4(f *File) bool {
 
 // Mqv matches a Sony / Mobile QuickTime  file.
 func Mqv(f *File) bool {
-	return ftyp(raw, []byte("mqt "))
+	return ftyp(f.Head, []byte("mqt "))
 }
 
 // M4a matches an audio M4A file.
 func M4a(f *File) bool {
-	return ftyp(raw, []byte("M4A "))
+	return ftyp(f.Head, []byte("M4A "))
 }
 
 // M4v matches an Appl4 M4V video file.
 func M4v(f *File) bool {
-	return ftyp(raw, []byte("M4V "), []byte("M4VH"), []byte("M4VP"))
+	return ftyp(f.Head, []byte("M4V "), []byte("M4VH"), []byte("M4VP"))
 }
 
 // Heic matches a High Efficiency Image Coding (HEIC) file.
 func Heic(f *File) bool {
-	return ftyp(raw, []byte("heic"), []byte("heix"))
+	return ftyp(f.Head, []byte("heic"), []byte("heix"))
 }
 
 // HeicSequence matches a High Efficiency Image Coding (HEIC) file sequence.
 func HeicSequence(f *File) bool {
-	return ftyp(raw, []byte("hevc"), []byte("hevx"))
+	return ftyp(f.Head, []byte("hevc"), []byte("hevx"))
 }
 
 // Heif matches a High Efficiency Image File Format (HEIF) file.
 func Heif(f *File) bool {
-	return ftyp(raw, []byte("mif1"), []byte("heim"), []byte("heis"), []byte("avic"))
+	return ftyp(f.Head, []byte("mif1"), []byte("heim"), []byte("heis"), []byte("avic"))
 }
 
 // HeifSequence matches a High Efficiency Image File Format (HEIF) file sequence.
 func HeifSequence(f *File) bool {
-	return ftyp(raw, []byte("msf1"), []byte("hevm"), []byte("hevs"), []byte("avcs"))
+	return ftyp(f.Head, []byte("msf1"), []byte("hevm"), []byte("hevs"), []byte("avcs"))
 }
 
 // Mj2 matches a Motion JPEG 2000 file: https://en.wikipedia.org/wiki/Motion_JPEG_2000.
 func Mj2(f *File) bool {
-	return ftyp(raw, []byte("mj2s"), []byte("mjp2"), []byte("MFSM"), []byte("MGSV"))
+	return ftyp(f.Head, []byte("mj2s"), []byte("mjp2"), []byte("MFSM"), []byte("MGSV"))
 }
 
 // Dvb matches a Digital Video Broadcasting file: https://dvb.org.
 // https://cconcolato.github.io/mp4ra/filetype.html
 // https://github.com/file/file/blob/512840337ead1076519332d24fefcaa8fac36e06/magic/Magdir/animation#L135-L154
 func Dvb(f *File) bool {
-	return ftyp(raw,
+	return ftyp(f.Head,
 		[]byte("dby1"), []byte("dsms"), []byte("dts1"), []byte("dts2"),
 		[]byte("dts3"), []byte("dxo "), []byte("dmb1"), []byte("dmpf"),
 		[]byte("drc1"), []byte("dv1a"), []byte("dv1b"), []byte("dv2a"),
@@ -101,16 +101,16 @@ func Dvb(f *File) bool {
 // https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-38190
 // https://github.com/apache/tika/blob/0f5570691133c75ac4472c3340354a6c4080b104/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml#L7758-L7777
 func QuickTime(f *File) bool {
-	if len(raw) < 12 {
+	if len(f.Head) < 12 {
 		return false
 	}
 	// First 4 bytes represent the size of the atom as unsigned int.
 	// Next 4 bytes are the type of the atom.
 	// For `ftyp` atoms check if first byte in size is 0, otherwise, a text file
 	// which happens to contain 'ftypqt  ' at index 4 will trigger a false positive.
-	if bytes.Equal(raw[4:12], []byte("ftypqt  ")) ||
-		bytes.Equal(raw[4:12], []byte("ftypmoov")) {
-		return raw[0] == 0x00
+	if bytes.Equal(f.Head[4:12], []byte("ftypqt  ")) ||
+		bytes.Equal(f.Head[4:12], []byte("ftypmoov")) {
+		return f.Head[0] == 0x00
 	}
 	basicAtomTypes := [][]byte{
 		[]byte("moov\x00"),
@@ -120,11 +120,11 @@ func QuickTime(f *File) bool {
 		[]byte("pnot\x00"),
 	}
 	for _, a := range basicAtomTypes {
-		if bytes.Equal(raw[4:9], a) {
+		if bytes.Equal(f.Head[4:9], a) {
 			return true
 		}
 	}
-	return bytes.Equal(raw[:8], []byte("\x00\x00\x00\x08wide"))
+	return bytes.Equal(f.Head[:8], []byte("\x00\x00\x00\x08wide"))
 }
 
 // Mp4 detects an .mp4 file. Mp4 detections only does a basic ftyp check.
@@ -132,15 +132,15 @@ func QuickTime(f *File) bool {
 // of all. Detection will default on video/mp4 for all ftyp files.
 // ISO_IEC_14496-12 is the specification for the iso container.
 func Mp4(f *File) bool {
-	if len(raw) < 12 {
+	if len(f.Head) < 12 {
 		return false
 	}
 	// ftyps are made out of boxes. The first 4 bytes of the box represent
 	// its size in big-endian uint32. First box is the ftyp box and it is small
 	// in size. Check most significant byte is 0 to filter out false positive
 	// text files that happen to contain the string "ftyp" at index 4.
-	if raw[0] != 0 {
+	if f.Head[0] != 0 {
 		return false
 	}
-	return bytes.Equal(raw[4:8], []byte("ftyp"))
+	return bytes.Equal(f.Head[4:8], []byte("ftyp"))
 }

--- a/internal/magic/geo.go
+++ b/internal/magic/geo.go
@@ -8,17 +8,17 @@ import (
 // Shp matches a shape format file.
 // https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
 func Shp(f *File) bool {
-	if len(raw) < 112 {
+	if len(f.Head) < 112 {
 		return false
 	}
 
-	if binary.BigEndian.Uint32(raw[0:4]) != 9994 ||
-		binary.BigEndian.Uint32(raw[4:8]) != 0 ||
-		binary.BigEndian.Uint32(raw[8:12]) != 0 ||
-		binary.BigEndian.Uint32(raw[12:16]) != 0 ||
-		binary.BigEndian.Uint32(raw[16:20]) != 0 ||
-		binary.BigEndian.Uint32(raw[20:24]) != 0 ||
-		binary.LittleEndian.Uint32(raw[28:32]) != 1000 {
+	if binary.BigEndian.Uint32(f.Head[0:4]) != 9994 ||
+		binary.BigEndian.Uint32(f.Head[4:8]) != 0 ||
+		binary.BigEndian.Uint32(f.Head[8:12]) != 0 ||
+		binary.BigEndian.Uint32(f.Head[12:16]) != 0 ||
+		binary.BigEndian.Uint32(f.Head[16:20]) != 0 ||
+		binary.BigEndian.Uint32(f.Head[20:24]) != 0 ||
+		binary.LittleEndian.Uint32(f.Head[28:32]) != 1000 {
 		return false
 	}
 
@@ -40,7 +40,7 @@ func Shp(f *File) bool {
 	}
 
 	for _, st := range shapeTypes {
-		if st == int(binary.LittleEndian.Uint32(raw[108:112])) {
+		if st == int(binary.LittleEndian.Uint32(f.Head[108:112])) {
 			return true
 		}
 	}
@@ -51,5 +51,5 @@ func Shp(f *File) bool {
 // Shx matches a shape index format file.
 // https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
 func Shx(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x27, 0x0A})
+	return bytes.HasPrefix(f.Head, []byte{0x00, 0x00, 0x27, 0x0A})
 }

--- a/internal/magic/geo.go
+++ b/internal/magic/geo.go
@@ -7,7 +7,7 @@ import (
 
 // Shp matches a shape format file.
 // https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
-func Shp(raw []byte, limit uint32) bool {
+func Shp(f *File) bool {
 	if len(raw) < 112 {
 		return false
 	}
@@ -50,6 +50,6 @@ func Shp(raw []byte, limit uint32) bool {
 
 // Shx matches a shape index format file.
 // https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
-func Shx(raw []byte, limit uint32) bool {
+func Shx(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x27, 0x0A})
 }

--- a/internal/magic/image.go
+++ b/internal/magic/image.go
@@ -5,136 +5,136 @@ import "bytes"
 // Png matches a Portable Network Graphics file.
 // https://www.w3.org/TR/PNG/
 func Png(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+	return bytes.HasPrefix(f.Head, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
 }
 
 // Apng matches an Animated Portable Network Graphics file.
 // https://wiki.mozilla.org/APNG_Specification
 func Apng(f *File) bool {
-	return offset(raw, []byte("acTL"), 37)
+	return offset(f.Head, []byte("acTL"), 37)
 }
 
 // Jpg matches a Joint Photographic Experts Group file.
 func Jpg(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0xFF, 0xD8, 0xFF})
+	return bytes.HasPrefix(f.Head, []byte{0xFF, 0xD8, 0xFF})
 }
 
 // Jp2 matches a JPEG 2000 Image file (ISO 15444-1).
 func Jp2(f *File) bool {
-	return jpeg2k(raw, []byte{0x6a, 0x70, 0x32, 0x20})
+	return jpeg2k(f.Head, []byte{0x6a, 0x70, 0x32, 0x20})
 }
 
 // Jpx matches a JPEG 2000 Image file (ISO 15444-2).
 func Jpx(f *File) bool {
-	return jpeg2k(raw, []byte{0x6a, 0x70, 0x78, 0x20})
+	return jpeg2k(f.Head, []byte{0x6a, 0x70, 0x78, 0x20})
 }
 
 // Jpm matches a JPEG 2000 Image file (ISO 15444-6).
 func Jpm(f *File) bool {
-	return jpeg2k(raw, []byte{0x6a, 0x70, 0x6D, 0x20})
+	return jpeg2k(f.Head, []byte{0x6a, 0x70, 0x6D, 0x20})
 }
 
 // Gif matches a Graphics Interchange Format file.
 func Gif(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("GIF87a")) ||
-		bytes.HasPrefix(raw, []byte("GIF89a"))
+	return bytes.HasPrefix(f.Head, []byte("GIF87a")) ||
+		bytes.HasPrefix(f.Head, []byte("GIF89a"))
 }
 
 // Bmp matches a bitmap image file.
 func Bmp(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x42, 0x4D})
+	return bytes.HasPrefix(f.Head, []byte{0x42, 0x4D})
 }
 
 // Ps matches a PostScript file.
 func Ps(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("%!PS-Adobe-"))
+	return bytes.HasPrefix(f.Head, []byte("%!PS-Adobe-"))
 }
 
 // Psd matches a Photoshop Document file.
 func Psd(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("8BPS"))
+	return bytes.HasPrefix(f.Head, []byte("8BPS"))
 }
 
 // Ico matches an ICO file.
 func Ico(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x01, 0x00}) ||
-		bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x02, 0x00})
+	return bytes.HasPrefix(f.Head, []byte{0x00, 0x00, 0x01, 0x00}) ||
+		bytes.HasPrefix(f.Head, []byte{0x00, 0x00, 0x02, 0x00})
 }
 
 // Icns matches an ICNS (Apple Icon Image format) file.
 func Icns(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("icns"))
+	return bytes.HasPrefix(f.Head, []byte("icns"))
 }
 
 // Tiff matches a Tagged Image File Format file.
 func Tiff(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x49, 0x49, 0x2A, 0x00}) ||
-		bytes.HasPrefix(raw, []byte{0x4D, 0x4D, 0x00, 0x2A})
+	return bytes.HasPrefix(f.Head, []byte{0x49, 0x49, 0x2A, 0x00}) ||
+		bytes.HasPrefix(f.Head, []byte{0x4D, 0x4D, 0x00, 0x2A})
 }
 
 // Bpg matches a Better Portable Graphics file.
 func Bpg(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x42, 0x50, 0x47, 0xFB})
+	return bytes.HasPrefix(f.Head, []byte{0x42, 0x50, 0x47, 0xFB})
 }
 
 // Xcf matches GIMP image data.
 func Xcf(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("gimp xcf"))
+	return bytes.HasPrefix(f.Head, []byte("gimp xcf"))
 }
 
 // Pat matches GIMP pattern data.
 func Pat(f *File) bool {
-	return offset(raw, []byte("GPAT"), 20)
+	return offset(f.Head, []byte("GPAT"), 20)
 }
 
 // Gbr matches GIMP brush data.
 func Gbr(f *File) bool {
-	return offset(raw, []byte("GIMP"), 20)
+	return offset(f.Head, []byte("GIMP"), 20)
 }
 
 // Hdr matches Radiance HDR image.
 // https://web.archive.org/web/20060913152809/http://local.wasp.uwa.edu.au/~pbourke/dataformats/pic/
 func Hdr(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("#?RADIANCE\n"))
+	return bytes.HasPrefix(f.Head, []byte("#?RADIANCE\n"))
 }
 
 // Xpm matches X PixMap image data.
 func Xpm(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x2F, 0x2A, 0x20, 0x58, 0x50, 0x4D, 0x20, 0x2A, 0x2F})
+	return bytes.HasPrefix(f.Head, []byte{0x2F, 0x2A, 0x20, 0x58, 0x50, 0x4D, 0x20, 0x2A, 0x2F})
 }
 
 // Jxs matches a JPEG XS coded image file (ISO/IEC 21122-3).
 func Jxs(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x53, 0x20, 0x0D, 0x0A, 0x87, 0x0A})
+	return bytes.HasPrefix(f.Head, []byte{0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x53, 0x20, 0x0D, 0x0A, 0x87, 0x0A})
 }
 
 // Jxr matches Microsoft HD JXR photo file.
 func Jxr(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x49, 0x49, 0xBC, 0x01})
+	return bytes.HasPrefix(f.Head, []byte{0x49, 0x49, 0xBC, 0x01})
 }
 
-func jpeg2k(raw []byte, sig []byte) bool {
-	if len(raw) < 24 {
+func jpeg2k(head []byte, sig []byte) bool {
+	if len(head) < 24 {
 		return false
 	}
 
-	if !bytes.Equal(raw[4:8], []byte{0x6A, 0x50, 0x20, 0x20}) &&
-		!bytes.Equal(raw[4:8], []byte{0x6A, 0x50, 0x32, 0x20}) {
+	if !bytes.Equal(head[4:8], []byte{0x6A, 0x50, 0x20, 0x20}) &&
+		!bytes.Equal(head[4:8], []byte{0x6A, 0x50, 0x32, 0x20}) {
 		return false
 	}
-	return bytes.Equal(raw[20:24], sig)
+	return bytes.Equal(head[20:24], sig)
 }
 
 // Webp matches a WebP file.
 func Webp(f *File) bool {
-	return len(raw) > 12 &&
-		bytes.Equal(raw[0:4], []byte("RIFF")) &&
-		bytes.Equal(raw[8:12], []byte{0x57, 0x45, 0x42, 0x50})
+	return len(f.Head) > 12 &&
+		bytes.Equal(f.Head[0:4], []byte("RIFF")) &&
+		bytes.Equal(f.Head[8:12], []byte{0x57, 0x45, 0x42, 0x50})
 }
 
-// Dwg matches a CAD drawing file.
+// Dwg matches a CAD df.Heading file.
 func Dwg(f *File) bool {
-	if len(raw) < 6 || raw[0] != 0x41 || raw[1] != 0x43 {
+	if len(f.Head) < 6 || f.Head[0] != 0x41 || f.Head[1] != 0x43 {
 		return false
 	}
 	dwgVersions := [][]byte{
@@ -156,7 +156,7 @@ func Dwg(f *File) bool {
 	}
 
 	for _, d := range dwgVersions {
-		if bytes.Equal(raw[2:6], d) {
+		if bytes.Equal(f.Head[2:6], d) {
 			return true
 		}
 	}
@@ -166,11 +166,11 @@ func Dwg(f *File) bool {
 
 // Jxl matches JPEG XL image file.
 func Jxl(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0xFF, 0x0A}) ||
-		bytes.HasPrefix(raw, []byte("\x00\x00\x00\x0cJXL\x20\x0d\x0a\x87\x0a"))
+	return bytes.HasPrefix(f.Head, []byte{0xFF, 0x0A}) ||
+		bytes.HasPrefix(f.Head, []byte("\x00\x00\x00\x0cJXL\x20\x0d\x0a\x87\x0a"))
 }
 
-// DXF matches Drawing Exchange Format AutoCAD file.
+// DXF matches Df.Heading Exchange Format AutoCAD file.
 // There does not seem to be a clear specification and the files in the wild
 // differ wildly.
 // https://images.autodesk.com/adsk/files/autocad_2012_pdf_dxf-reference_enu.pdf
@@ -181,8 +181,8 @@ func Jxl(f *File) bool {
 // xxd -l 16 {} | sort | uniq.
 // These signatures are only for the ASCII version of DXF. There is a binary version too.
 func DXF(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("  0\x0ASECTION\x0A")) ||
-		bytes.HasPrefix(raw, []byte("  0\x0D\x0ASECTION\x0D\x0A")) ||
-		bytes.HasPrefix(raw, []byte("0\x0ASECTION\x0A")) ||
-		bytes.HasPrefix(raw, []byte("0\x0D\x0ASECTION\x0D\x0A"))
+	return bytes.HasPrefix(f.Head, []byte("  0\x0ASECTION\x0A")) ||
+		bytes.HasPrefix(f.Head, []byte("  0\x0D\x0ASECTION\x0D\x0A")) ||
+		bytes.HasPrefix(f.Head, []byte("0\x0ASECTION\x0A")) ||
+		bytes.HasPrefix(f.Head, []byte("0\x0D\x0ASECTION\x0D\x0A"))
 }

--- a/internal/magic/image.go
+++ b/internal/magic/image.go
@@ -4,112 +4,112 @@ import "bytes"
 
 // Png matches a Portable Network Graphics file.
 // https://www.w3.org/TR/PNG/
-func Png(raw []byte, _ uint32) bool {
+func Png(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
 }
 
 // Apng matches an Animated Portable Network Graphics file.
 // https://wiki.mozilla.org/APNG_Specification
-func Apng(raw []byte, _ uint32) bool {
+func Apng(f *File) bool {
 	return offset(raw, []byte("acTL"), 37)
 }
 
 // Jpg matches a Joint Photographic Experts Group file.
-func Jpg(raw []byte, _ uint32) bool {
+func Jpg(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0xFF, 0xD8, 0xFF})
 }
 
 // Jp2 matches a JPEG 2000 Image file (ISO 15444-1).
-func Jp2(raw []byte, _ uint32) bool {
+func Jp2(f *File) bool {
 	return jpeg2k(raw, []byte{0x6a, 0x70, 0x32, 0x20})
 }
 
 // Jpx matches a JPEG 2000 Image file (ISO 15444-2).
-func Jpx(raw []byte, _ uint32) bool {
+func Jpx(f *File) bool {
 	return jpeg2k(raw, []byte{0x6a, 0x70, 0x78, 0x20})
 }
 
 // Jpm matches a JPEG 2000 Image file (ISO 15444-6).
-func Jpm(raw []byte, _ uint32) bool {
+func Jpm(f *File) bool {
 	return jpeg2k(raw, []byte{0x6a, 0x70, 0x6D, 0x20})
 }
 
 // Gif matches a Graphics Interchange Format file.
-func Gif(raw []byte, _ uint32) bool {
+func Gif(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("GIF87a")) ||
 		bytes.HasPrefix(raw, []byte("GIF89a"))
 }
 
 // Bmp matches a bitmap image file.
-func Bmp(raw []byte, _ uint32) bool {
+func Bmp(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x42, 0x4D})
 }
 
 // Ps matches a PostScript file.
-func Ps(raw []byte, _ uint32) bool {
+func Ps(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("%!PS-Adobe-"))
 }
 
 // Psd matches a Photoshop Document file.
-func Psd(raw []byte, _ uint32) bool {
+func Psd(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("8BPS"))
 }
 
 // Ico matches an ICO file.
-func Ico(raw []byte, _ uint32) bool {
+func Ico(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x01, 0x00}) ||
 		bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x02, 0x00})
 }
 
 // Icns matches an ICNS (Apple Icon Image format) file.
-func Icns(raw []byte, _ uint32) bool {
+func Icns(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("icns"))
 }
 
 // Tiff matches a Tagged Image File Format file.
-func Tiff(raw []byte, _ uint32) bool {
+func Tiff(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x49, 0x49, 0x2A, 0x00}) ||
 		bytes.HasPrefix(raw, []byte{0x4D, 0x4D, 0x00, 0x2A})
 }
 
 // Bpg matches a Better Portable Graphics file.
-func Bpg(raw []byte, _ uint32) bool {
+func Bpg(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x42, 0x50, 0x47, 0xFB})
 }
 
 // Xcf matches GIMP image data.
-func Xcf(raw []byte, _ uint32) bool {
+func Xcf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("gimp xcf"))
 }
 
 // Pat matches GIMP pattern data.
-func Pat(raw []byte, _ uint32) bool {
+func Pat(f *File) bool {
 	return offset(raw, []byte("GPAT"), 20)
 }
 
 // Gbr matches GIMP brush data.
-func Gbr(raw []byte, _ uint32) bool {
+func Gbr(f *File) bool {
 	return offset(raw, []byte("GIMP"), 20)
 }
 
 // Hdr matches Radiance HDR image.
 // https://web.archive.org/web/20060913152809/http://local.wasp.uwa.edu.au/~pbourke/dataformats/pic/
-func Hdr(raw []byte, _ uint32) bool {
+func Hdr(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("#?RADIANCE\n"))
 }
 
 // Xpm matches X PixMap image data.
-func Xpm(raw []byte, _ uint32) bool {
+func Xpm(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x2F, 0x2A, 0x20, 0x58, 0x50, 0x4D, 0x20, 0x2A, 0x2F})
 }
 
 // Jxs matches a JPEG XS coded image file (ISO/IEC 21122-3).
-func Jxs(raw []byte, _ uint32) bool {
+func Jxs(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x53, 0x20, 0x0D, 0x0A, 0x87, 0x0A})
 }
 
 // Jxr matches Microsoft HD JXR photo file.
-func Jxr(raw []byte, _ uint32) bool {
+func Jxr(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x49, 0x49, 0xBC, 0x01})
 }
 
@@ -126,14 +126,14 @@ func jpeg2k(raw []byte, sig []byte) bool {
 }
 
 // Webp matches a WebP file.
-func Webp(raw []byte, _ uint32) bool {
+func Webp(f *File) bool {
 	return len(raw) > 12 &&
 		bytes.Equal(raw[0:4], []byte("RIFF")) &&
 		bytes.Equal(raw[8:12], []byte{0x57, 0x45, 0x42, 0x50})
 }
 
 // Dwg matches a CAD drawing file.
-func Dwg(raw []byte, _ uint32) bool {
+func Dwg(f *File) bool {
 	if len(raw) < 6 || raw[0] != 0x41 || raw[1] != 0x43 {
 		return false
 	}
@@ -165,7 +165,7 @@ func Dwg(raw []byte, _ uint32) bool {
 }
 
 // Jxl matches JPEG XL image file.
-func Jxl(raw []byte, _ uint32) bool {
+func Jxl(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0xFF, 0x0A}) ||
 		bytes.HasPrefix(raw, []byte("\x00\x00\x00\x0cJXL\x20\x0d\x0a\x87\x0a"))
 }
@@ -180,7 +180,7 @@ func Jxl(raw []byte, _ uint32) bool {
 // https://sembiance.com/fileFormatSamples/poly/dxf/ and then
 // xxd -l 16 {} | sort | uniq.
 // These signatures are only for the ASCII version of DXF. There is a binary version too.
-func DXF(raw []byte, _ uint32) bool {
+func DXF(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("  0\x0ASECTION\x0A")) ||
 		bytes.HasPrefix(raw, []byte("  0\x0D\x0ASECTION\x0D\x0A")) ||
 		bytes.HasPrefix(raw, []byte("0\x0ASECTION\x0A")) ||

--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -3,7 +3,6 @@ package magic
 
 import (
 	"bytes"
-	"io"
 
 	"github.com/gabriel-vasile/mimetype/internal/scan"
 )
@@ -14,8 +13,6 @@ import (
 type File struct {
 	// Head is the first bytes from the file (up to readLimit length)
 	Head scan.Bytes
-	// Tail represents the content following Head.
-	Tail io.Reader
 
 	ReadLimit      uint32
 	geo, har, gltf bool

--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -17,10 +17,8 @@ type File struct {
 	// Tail represents the content following Head.
 	Tail io.Reader
 
-	// Many file formats have their signature in the first line of text.
-	// Cache FirstLine to avoid having to extract it in several places.
-	FirstLine scan.Bytes
-	ReadLimit uint32
+	ReadLimit      uint32
+	geo, har, gltf bool
 }
 
 // Detector functions exist for each file format. They report whether the file

--- a/internal/magic/magic.go
+++ b/internal/magic/magic.go
@@ -26,7 +26,7 @@ type File struct {
 // Detector functions exist for each file format. They report whether the file
 // looks like a specific format. Additionally, they collect file facts and
 // cache them in f for other Detectors to use.
-type Detector func(f File) bool
+type Detector func(f *File) bool
 type xmlSig struct {
 	// the local name of the root tag
 	localName []byte

--- a/internal/magic/ms_office.go
+++ b/internal/magic/ms_office.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Xlsx matches a Microsoft Excel 2007 file.
-func Xlsx(raw []byte, limit uint32) bool {
+func Xlsx(f *File) bool {
 	return msoxml(raw, zipEntries{{
 		name: []byte("xl/"),
 		dir:  true,
@@ -14,7 +14,7 @@ func Xlsx(raw []byte, limit uint32) bool {
 }
 
 // Docx matches a Microsoft Word 2007 file.
-func Docx(raw []byte, limit uint32) bool {
+func Docx(f *File) bool {
 	return msoxml(raw, zipEntries{{
 		name: []byte("word/"),
 		dir:  true,
@@ -22,7 +22,7 @@ func Docx(raw []byte, limit uint32) bool {
 }
 
 // Pptx matches a Microsoft PowerPoint 2007 file.
-func Pptx(raw []byte, limit uint32) bool {
+func Pptx(f *File) bool {
 	return msoxml(raw, zipEntries{{
 		name: []byte("ppt/"),
 		dir:  true,
@@ -30,7 +30,7 @@ func Pptx(raw []byte, limit uint32) bool {
 }
 
 // Visio matches a Microsoft Visio 2013+ file.
-func Visio(raw []byte, limit uint32) bool {
+func Visio(f *File) bool {
 	return msoxml(raw, zipEntries{{
 		name: []byte("visio/"),
 		dir:  true,
@@ -40,13 +40,13 @@ func Visio(raw []byte, limit uint32) bool {
 // Ole matches an Open Linking and Embedding file.
 //
 // https://en.wikipedia.org/wiki/Object_Linking_and_Embedding
-func Ole(raw []byte, limit uint32) bool {
+func Ole(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1})
 }
 
 // Doc matches a Microsoft Word 97-2003 file.
 // See: https://github.com/decalage2/oletools/blob/412ee36ae45e70f42123e835871bac956d958461/oletools/common/clsid.py
-func Doc(raw []byte, _ uint32) bool {
+func Doc(f *File) bool {
 	clsids := [][]byte{
 		// Microsoft Word 97-2003 Document (Word.Document.8)
 		{0x06, 0x09, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46},
@@ -66,7 +66,7 @@ func Doc(raw []byte, _ uint32) bool {
 }
 
 // Ppt matches a Microsoft PowerPoint 97-2003 file or a PowerPoint 95 presentation.
-func Ppt(raw []byte, limit uint32) bool {
+func Ppt(f *File) bool {
 	// Root CLSID test is the safest way to detect identify OLE, however, the format
 	// often places the root CLSID at the end of the file.
 	if matchOleClsid(raw, []byte{
@@ -104,7 +104,7 @@ func Ppt(raw []byte, limit uint32) bool {
 }
 
 // Xls matches a Microsoft Excel 97-2003 file.
-func Xls(raw []byte, limit uint32) bool {
+func Xls(f *File) bool {
 	// Root CLSID test is the safest way to detect identify OLE, however, the format
 	// often places the root CLSID at the end of the file.
 	if matchOleClsid(raw, []byte{
@@ -139,7 +139,7 @@ func Xls(raw []byte, limit uint32) bool {
 }
 
 // Pub matches a Microsoft Publisher file.
-func Pub(raw []byte, limit uint32) bool {
+func Pub(f *File) bool {
 	return matchOleClsid(raw, []byte{
 		0x01, 0x12, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
@@ -147,7 +147,7 @@ func Pub(raw []byte, limit uint32) bool {
 }
 
 // Msg matches a Microsoft Outlook email file.
-func Msg(raw []byte, limit uint32) bool {
+func Msg(f *File) bool {
 	return matchOleClsid(raw, []byte{
 		0x0B, 0x0D, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
@@ -156,7 +156,7 @@ func Msg(raw []byte, limit uint32) bool {
 
 // Msi matches a Microsoft Windows Installer file.
 // http://fileformats.archiveteam.org/wiki/Microsoft_Compound_File
-func Msi(raw []byte, limit uint32) bool {
+func Msi(f *File) bool {
 	return matchOleClsid(raw, []byte{
 		0x84, 0x10, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46,
@@ -164,7 +164,7 @@ func Msi(raw []byte, limit uint32) bool {
 }
 
 // One matches a Microsoft OneNote file.
-func One(raw []byte, limit uint32) bool {
+func One(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{
 		0xe4, 0x52, 0x5c, 0x7b, 0x8c, 0xd8, 0xa7, 0x4d,
 		0xae, 0xb1, 0x53, 0x78, 0xd0, 0x29, 0x96, 0xd3,
@@ -200,7 +200,7 @@ func matchOleClsid(in []byte, clsid []byte) bool {
 }
 
 // WPD matches a WordPerfect document.
-func WPD(raw []byte, _ uint32) bool {
+func WPD(f *File) bool {
 	if len(raw) < 10 {
 		return false
 	}

--- a/internal/magic/netpbm.go
+++ b/internal/magic/netpbm.go
@@ -11,32 +11,32 @@ import (
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
 func NetPBM(f *File) bool {
-	return netp(raw, "P1\n", "P4\n")
+	return netp(f.Head, "P1\n", "P4\n")
 }
 
 // NetPGM matches a Netpbm Portable GrayMap ASCII/Binary file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
 func NetPGM(f *File) bool {
-	return netp(raw, "P2\n", "P5\n")
+	return netp(f.Head, "P2\n", "P5\n")
 }
 
 // NetPPM matches a Netpbm Portable PixMap ASCII/Binary file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
 func NetPPM(f *File) bool {
-	return netp(raw, "P3\n", "P6\n")
+	return netp(f.Head, "P3\n", "P6\n")
 }
 
 // NetPAM matches a Netpbm Portable Arbitrary Map file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
 func NetPAM(f *File) bool {
-	if !bytes.HasPrefix(raw, []byte("P7\n")) {
+	if !bytes.HasPrefix(f.Head, []byte("P7\n")) {
 		return false
 	}
 	w, h, d, m, e := false, false, false, false, false
-	s := scan.Bytes(raw)
+	s := scan.Bytes(f.Head)
 	var l scan.Bytes
 	// Read line by line.
 	for i := 0; i < 128; i++ {

--- a/internal/magic/netpbm.go
+++ b/internal/magic/netpbm.go
@@ -10,28 +10,28 @@ import (
 // NetPBM matches a Netpbm Portable BitMap ASCII/Binary file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
-func NetPBM(raw []byte, _ uint32) bool {
+func NetPBM(f *File) bool {
 	return netp(raw, "P1\n", "P4\n")
 }
 
 // NetPGM matches a Netpbm Portable GrayMap ASCII/Binary file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
-func NetPGM(raw []byte, _ uint32) bool {
+func NetPGM(f *File) bool {
 	return netp(raw, "P2\n", "P5\n")
 }
 
 // NetPPM matches a Netpbm Portable PixMap ASCII/Binary file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
-func NetPPM(raw []byte, _ uint32) bool {
+func NetPPM(f *File) bool {
 	return netp(raw, "P3\n", "P6\n")
 }
 
 // NetPAM matches a Netpbm Portable Arbitrary Map file.
 //
 // See: https://en.wikipedia.org/wiki/Netpbm
-func NetPAM(raw []byte, _ uint32) bool {
+func NetPAM(f *File) bool {
 	if !bytes.HasPrefix(raw, []byte("P7\n")) {
 		return false
 	}

--- a/internal/magic/ogg.go
+++ b/internal/magic/ogg.go
@@ -23,20 +23,20 @@ import (
 
 // Ogg matches an Ogg file.
 func Ogg(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x4F\x67\x67\x53\x00"))
+	return bytes.HasPrefix(f.Head, []byte("\x4F\x67\x67\x53\x00"))
 }
 
 // OggAudio matches an audio ogg file.
 func OggAudio(f *File) bool {
-	return len(raw) >= 37 && (bytes.HasPrefix(raw[28:], []byte("\x7fFLAC")) ||
-		bytes.HasPrefix(raw[28:], []byte("\x01vorbis")) ||
-		bytes.HasPrefix(raw[28:], []byte("OpusHead")) ||
-		bytes.HasPrefix(raw[28:], []byte("Speex\x20\x20\x20")))
+	return len(f.Head) >= 37 && (bytes.HasPrefix(f.Head[28:], []byte("\x7fFLAC")) ||
+		bytes.HasPrefix(f.Head[28:], []byte("\x01vorbis")) ||
+		bytes.HasPrefix(f.Head[28:], []byte("OpusHead")) ||
+		bytes.HasPrefix(f.Head[28:], []byte("Speex\x20\x20\x20")))
 }
 
 // OggVideo matches a video ogg file.
 func OggVideo(f *File) bool {
-	return len(raw) >= 37 && (bytes.HasPrefix(raw[28:], []byte("\x80theora")) ||
-		bytes.HasPrefix(raw[28:], []byte("fishead\x00")) ||
-		bytes.HasPrefix(raw[28:], []byte("\x01video\x00\x00\x00"))) // OGM video
+	return len(f.Head) >= 37 && (bytes.HasPrefix(f.Head[28:], []byte("\x80theora")) ||
+		bytes.HasPrefix(f.Head[28:], []byte("fishead\x00")) ||
+		bytes.HasPrefix(f.Head[28:], []byte("\x01video\x00\x00\x00"))) // OGM video
 }

--- a/internal/magic/ogg.go
+++ b/internal/magic/ogg.go
@@ -22,12 +22,12 @@ import (
 */
 
 // Ogg matches an Ogg file.
-func Ogg(raw []byte, limit uint32) bool {
+func Ogg(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x4F\x67\x67\x53\x00"))
 }
 
 // OggAudio matches an audio ogg file.
-func OggAudio(raw []byte, limit uint32) bool {
+func OggAudio(f *File) bool {
 	return len(raw) >= 37 && (bytes.HasPrefix(raw[28:], []byte("\x7fFLAC")) ||
 		bytes.HasPrefix(raw[28:], []byte("\x01vorbis")) ||
 		bytes.HasPrefix(raw[28:], []byte("OpusHead")) ||
@@ -35,7 +35,7 @@ func OggAudio(raw []byte, limit uint32) bool {
 }
 
 // OggVideo matches a video ogg file.
-func OggVideo(raw []byte, limit uint32) bool {
+func OggVideo(f *File) bool {
 	return len(raw) >= 37 && (bytes.HasPrefix(raw[28:], []byte("\x80theora")) ||
 		bytes.HasPrefix(raw[28:], []byte("fishead\x00")) ||
 		bytes.HasPrefix(raw[28:], []byte("\x01video\x00\x00\x00"))) // OGM video

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -12,7 +12,7 @@ import (
 
 // HTML matches a Hypertext Markup Language file.
 func HTML(f *File) bool {
-	return markup(raw,
+	return markup(f.Head,
 		[]byte("<!DOCTYPE HTML"),
 		[]byte("<HTML"),
 		[]byte("<HEAD"),
@@ -35,33 +35,33 @@ func HTML(f *File) bool {
 
 // XML matches an Extensible Markup Language file.
 func XML(f *File) bool {
-	return markup(raw, []byte("<?XML"))
+	return markup(f.Head, []byte("<?XML"))
 }
 
 // Owl2 matches an Owl ontology file.
 func Owl2(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<Ontology"), []byte(`xmlns="http://www.w3.org/2002/07/owl#"`)},
 	)
 }
 
 // Rss matches a Rich Site Summary file.
 func Rss(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<rss"), []byte{}},
 	)
 }
 
 // Atom matches an Atom Syndication Format file.
 func Atom(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<feed"), []byte(`xmlns="http://www.w3.org/2005/Atom"`)},
 	)
 }
 
 // Kml matches a Keyhole Markup Language file.
 func Kml(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<kml"), []byte(`xmlns="http://www.opengis.net/kml/2.2"`)},
 		xmlSig{[]byte("<kml"), []byte(`xmlns="http://earth.google.com/kml/2.0"`)},
 		xmlSig{[]byte("<kml"), []byte(`xmlns="http://earth.google.com/kml/2.1"`)},
@@ -71,21 +71,21 @@ func Kml(f *File) bool {
 
 // Xliff matches a XML Localization Interchange File Format file.
 func Xliff(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<xliff"), []byte(`xmlns="urn:oasis:names:tc:xliff:document:1.2"`)},
 	)
 }
 
 // Collada matches a COLLAborative Design Activity file.
 func Collada(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<COLLADA"), []byte(`xmlns="http://www.collada.org/2005/11/COLLADASchema"`)},
 	)
 }
 
 // Gml matches a Geography Markup Language file.
 func Gml(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte{}, []byte(`xmlns:gml="http://www.opengis.net/gml"`)},
 		xmlSig{[]byte{}, []byte(`xmlns:gml="http://www.opengis.net/gml/3.2"`)},
 		xmlSig{[]byte{}, []byte(`xmlns:gml="http://www.opengis.net/gml/3.3/exr"`)},
@@ -94,53 +94,53 @@ func Gml(f *File) bool {
 
 // Gpx matches a GPS Exchange Format file.
 func Gpx(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<gpx"), []byte(`xmlns="http://www.topografix.com/GPX/1/1"`)},
 	)
 }
 
 // Tcx matches a Training Center XML file.
 func Tcx(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<TrainingCenterDatabase"), []byte(`xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"`)},
 	)
 }
 
 // X3d matches an Extensible 3D Graphics file.
 func X3d(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<X3D"), []byte(`xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"`)},
 	)
 }
 
 // Amf matches an Additive Manufacturing XML file.
 func Amf(f *File) bool {
-	return xml(raw, xmlSig{[]byte("<amf"), []byte{}})
+	return xml(f.Head, xmlSig{[]byte("<amf"), []byte{}})
 }
 
 // Threemf matches a 3D Manufacturing Format file.
 func Threemf(f *File) bool {
-	return xml(raw,
+	return xml(f.Head,
 		xmlSig{[]byte("<model"), []byte(`xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"`)},
 	)
 }
 
 // Xfdf matches a XML Forms Data Format file.
 func Xfdf(f *File) bool {
-	return xml(raw, xmlSig{[]byte("<xfdf"), []byte(`xmlns="http://ns.adobe.com/xfdf/"`)})
+	return xml(f.Head, xmlSig{[]byte("<xfdf"), []byte(`xmlns="http://ns.adobe.com/xfdf/"`)})
 }
 
 // VCard matches a Virtual Contact File.
 func VCard(f *File) bool {
-	return ciPrefix(raw, []byte("BEGIN:VCARD\n"), []byte("BEGIN:VCARD\r\n"))
+	return ciPrefix(f.Head, []byte("BEGIN:VCARD\n"), []byte("BEGIN:VCARD\r\n"))
 }
 
 // ICalendar matches a iCalendar file.
 func ICalendar(f *File) bool {
-	return ciPrefix(raw, []byte("BEGIN:VCALENDAR\n"), []byte("BEGIN:VCALENDAR\r\n"))
+	return ciPrefix(f.Head, []byte("BEGIN:VCALENDAR\n"), []byte("BEGIN:VCALENDAR\r\n"))
 }
 func phpPageF(f *File) bool {
-	return ciPrefix(raw,
+	return ciPrefix(f.Head,
 		[]byte("<?PHP"),
 		[]byte("<?\n"),
 		[]byte("<?\r"),
@@ -148,7 +148,7 @@ func phpPageF(f *File) bool {
 	)
 }
 func phpScriptF(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS,
 		[]byte("/usr/local/bin/php"),
 		[]byte("/usr/bin/php"),
@@ -159,7 +159,7 @@ func phpScriptF(f *File) bool {
 
 // Js matches a Javascript file.
 func Js(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS,
 		[]byte("/bin/node"),
 		[]byte("/usr/bin/node"),
@@ -174,7 +174,7 @@ func Js(f *File) bool {
 
 // Lua matches a Lua programming language file.
 func Lua(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/lua"),
 		[]byte("/usr/local/bin/lua"),
@@ -185,7 +185,7 @@ func Lua(f *File) bool {
 
 // Perl matches a Perl programming language file.
 func Perl(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/perl"),
 		[]byte("/usr/bin/env perl"),
@@ -195,7 +195,7 @@ func Perl(f *File) bool {
 
 // Python matches a Python programming language file.
 func Python(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS,
 		[]byte("/usr/bin/python"),
 		[]byte("/usr/local/bin/python"),
@@ -215,7 +215,7 @@ func Python(f *File) bool {
 
 // Ruby matches a Ruby programming language file.
 func Ruby(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS,
 		[]byte("/usr/bin/ruby"),
 		[]byte("/usr/local/bin/ruby"),
@@ -226,7 +226,7 @@ func Ruby(f *File) bool {
 
 // Tcl matches a Tcl programming language file.
 func Tcl(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS,
 		[]byte("/usr/bin/tcl"),
 		[]byte("/usr/local/bin/tcl"),
@@ -245,12 +245,12 @@ func Tcl(f *File) bool {
 
 // Rtf matches a Rich Text Format file.
 func Rtf(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("{\\rtf"))
+	return bytes.HasPrefix(f.Head, []byte("{\\rtf"))
 }
 
 // Shell matches a shell script file.
 func Shell(f *File) bool {
-	return shebang(raw,
+	return shebang(f.Head,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/bin/sh"),
 		[]byte("/bin/bash"),
@@ -286,12 +286,12 @@ func Shell(f *File) bool {
 // sure it should. Linux file utility also requires a BOM for UTF16 and UTF32.
 func Text(f *File) bool {
 	// First look for BOM.
-	if cset := charset.FromBOM(raw); cset != "" {
+	if cset := charset.FromBOM(f.Head); cset != "" {
 		return true
 	}
 	// Binary data bytes as defined here: https://mimesniff.spec.whatwg.org/#binary-data-byte
-	for i := 0; i < min(len(raw), 4096); i++ {
-		b := raw[i]
+	for i := 0; i < min(len(f.Head), 4096); i++ {
+		b := f.Head[i]
 		if b <= 0x08 ||
 			b == 0x0B ||
 			0x0E <= b && b <= 0x1A ||
@@ -304,8 +304,8 @@ func Text(f *File) bool {
 
 // XHTML matches an XHTML file. This check depends on the XML check to have passed.
 func XHTML(f *File) bool {
-	raw = raw[:min(len(raw), 1024)]
-	b := scan.Bytes(raw)
+	f.Head = f.Head[:min(len(f.Head), 1024)]
+	b := scan.Bytes(f.Head)
 	i, _ := b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase)
 	if i != -1 {
 		return true
@@ -316,17 +316,17 @@ func XHTML(f *File) bool {
 
 // Php matches a PHP: Hypertext Preprocessor file.
 func Php(f *File) bool {
-	if res := phpPageF(raw, limit); res {
+	if res := phpPageF(f); res {
 		return res
 	}
-	return phpScriptF(raw, limit)
+	return phpScriptF(f)
 }
 
 // JSON matches a JavaScript Object Notation file.
 func JSON(f *File) bool {
 	// #175 A single JSON string, number or bool is not considered JSON.
 	// JSON objects and arrays are reported as JSON.
-	return jsonHelper(raw, limit, json.QueryNone, json.TokObject|json.TokArray)
+	return jsonHelper(f, json.QueryNone, json.TokObject|json.TokArray)
 }
 
 // GeoJSON matches a RFC 7946 GeoJSON file.
@@ -334,13 +334,13 @@ func JSON(f *File) bool {
 // GeoJSON detection implies searching for key:value pairs like: `"type": "Feature"`
 // in the input.
 func GeoJSON(f *File) bool {
-	return jsonHelper(raw, limit, json.QueryGeo, json.TokObject)
+	return jsonHelper(f, json.QueryGeo, json.TokObject)
 }
 
 // HAR matches a HAR Spec file.
 // Spec: http://www.softwareishard.com/blog/har-12-spec/
 func HAR(f *File) bool {
-	return jsonHelper(raw, limit, json.QueryHAR, json.TokObject)
+	return jsonHelper(f, json.QueryHAR, json.TokObject)
 }
 
 // GLTF matches a GL Transmission Format (JSON) file.
@@ -349,38 +349,38 @@ func HAR(f *File) bool {
 // [glTF specification]: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
 // [IANA glTF entry]: https://www.iana.org/assignments/media-types/model/gltf+json
 func GLTF(f *File) bool {
-	return jsonHelper(raw, limit, json.QueryGLTF, json.TokObject)
+	return jsonHelper(f, json.QueryGLTF, json.TokObject)
 }
 
 func jsonHelper(f *File, q string, wantTok int) bool {
-	if !json.LooksLikeObjectOrArray(raw) {
+	if !json.LooksLikeObjectOrArray(f.Head) {
 		return false
 	}
-	lraw := len(raw)
-	parsed, inspected, firstToken, querySatisfied := json.Parse(q, raw)
+	lHead := len(f.Head)
+	parsed, inspected, firstToken, querySatisfied := json.Parse(q, f.Head)
 	if !querySatisfied || firstToken&wantTok == 0 {
 		return false
 	}
 
 	// If the full file content was provided, check that the whole input was parsed.
-	if limit == 0 || lraw < int(limit) {
-		return parsed == lraw
+	if f.ReadLimit == 0 || lHead < int(f.ReadLimit) {
+		return parsed == lHead
 	}
 
 	// If a section of the file was provided, check if all of it was inspected.
 	// In other words, check that if there was a problem parsing, that problem
 	// occured at the last byte in the input.
-	return inspected == lraw && lraw > 0
+	return inspected == lHead && lHead > 0
 }
 
-// NdJSON matches a Newline delimited JSON file. All complete lines from raw
+// NdJSON matches a Newline delimited JSON file. All complete lines from f.Head
 // must be valid JSON documents meaning they contain one of the valid JSON data
 // types.
 func NdJSON(f *File) bool {
 	lCount, objOrArr := 0, 0
 
-	s := scan.Bytes(raw)
-	s.DropLastLine(limit)
+	s := scan.Bytes(f.Head)
+	s.DropLastLine(f.ReadLimit)
 	var l scan.Bytes
 	for len(s) != 0 {
 		l = s.Line()
@@ -399,7 +399,7 @@ func NdJSON(f *File) bool {
 
 // Svg matches a SVG file.
 func Svg(f *File) bool {
-	return svgWithoutXMLDeclaration(raw) || svgWithXMLDeclaration(raw)
+	return svgWithoutXMLDeclaration(f.Head) || svgWithXMLDeclaration(f.Head)
 }
 
 // svgWithoutXMLDeclaration matches a SVG image that does not have an XML header.
@@ -471,7 +471,7 @@ func svgWithXMLDeclaration(s scan.Bytes) bool {
 
 // Srt matches a SubRip file.
 func Srt(f *File) bool {
-	s := scan.Bytes(raw)
+	s := scan.Bytes(f.Head)
 	line := s.Line()
 
 	// First line must be 1.
@@ -527,12 +527,12 @@ func Vtt(f *File) bool {
 		{0x57, 0x45, 0x42, 0x56, 0x54, 0x54, 0x09},                   // "WEBVTT" and a horizontal tab
 	}
 	for _, p := range prefixes {
-		if bytes.HasPrefix(raw, p) {
+		if bytes.HasPrefix(f.Head, p) {
 			return true
 		}
 	}
 
 	// Exact match.
-	return bytes.Equal(raw, []byte{0xEF, 0xBB, 0xBF, 0x57, 0x45, 0x42, 0x56, 0x54, 0x54}) || // UTF-8 BOM and "WEBVTT"
-		bytes.Equal(raw, []byte{0x57, 0x45, 0x42, 0x56, 0x54, 0x54}) // "WEBVTT"
+	return bytes.Equal(f.Head, []byte{0xEF, 0xBB, 0xBF, 0x57, 0x45, 0x42, 0x56, 0x54, 0x54}) || // UTF-8 BOM and "WEBVTT"
+		bytes.Equal(f.Head, []byte{0x57, 0x45, 0x42, 0x56, 0x54, 0x54}) // "WEBVTT"
 }

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -11,7 +11,7 @@ import (
 )
 
 // HTML matches a Hypertext Markup Language file.
-func HTML(raw []byte, _ uint32) bool {
+func HTML(f *File) bool {
 	return markup(raw,
 		[]byte("<!DOCTYPE HTML"),
 		[]byte("<HTML"),
@@ -34,33 +34,33 @@ func HTML(raw []byte, _ uint32) bool {
 }
 
 // XML matches an Extensible Markup Language file.
-func XML(raw []byte, _ uint32) bool {
+func XML(f *File) bool {
 	return markup(raw, []byte("<?XML"))
 }
 
 // Owl2 matches an Owl ontology file.
-func Owl2(raw []byte, _ uint32) bool {
+func Owl2(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<Ontology"), []byte(`xmlns="http://www.w3.org/2002/07/owl#"`)},
 	)
 }
 
 // Rss matches a Rich Site Summary file.
-func Rss(raw []byte, _ uint32) bool {
+func Rss(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<rss"), []byte{}},
 	)
 }
 
 // Atom matches an Atom Syndication Format file.
-func Atom(raw []byte, _ uint32) bool {
+func Atom(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<feed"), []byte(`xmlns="http://www.w3.org/2005/Atom"`)},
 	)
 }
 
 // Kml matches a Keyhole Markup Language file.
-func Kml(raw []byte, _ uint32) bool {
+func Kml(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<kml"), []byte(`xmlns="http://www.opengis.net/kml/2.2"`)},
 		xmlSig{[]byte("<kml"), []byte(`xmlns="http://earth.google.com/kml/2.0"`)},
@@ -70,21 +70,21 @@ func Kml(raw []byte, _ uint32) bool {
 }
 
 // Xliff matches a XML Localization Interchange File Format file.
-func Xliff(raw []byte, _ uint32) bool {
+func Xliff(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<xliff"), []byte(`xmlns="urn:oasis:names:tc:xliff:document:1.2"`)},
 	)
 }
 
 // Collada matches a COLLAborative Design Activity file.
-func Collada(raw []byte, _ uint32) bool {
+func Collada(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<COLLADA"), []byte(`xmlns="http://www.collada.org/2005/11/COLLADASchema"`)},
 	)
 }
 
 // Gml matches a Geography Markup Language file.
-func Gml(raw []byte, _ uint32) bool {
+func Gml(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte{}, []byte(`xmlns:gml="http://www.opengis.net/gml"`)},
 		xmlSig{[]byte{}, []byte(`xmlns:gml="http://www.opengis.net/gml/3.2"`)},
@@ -93,53 +93,53 @@ func Gml(raw []byte, _ uint32) bool {
 }
 
 // Gpx matches a GPS Exchange Format file.
-func Gpx(raw []byte, _ uint32) bool {
+func Gpx(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<gpx"), []byte(`xmlns="http://www.topografix.com/GPX/1/1"`)},
 	)
 }
 
 // Tcx matches a Training Center XML file.
-func Tcx(raw []byte, _ uint32) bool {
+func Tcx(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<TrainingCenterDatabase"), []byte(`xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"`)},
 	)
 }
 
 // X3d matches an Extensible 3D Graphics file.
-func X3d(raw []byte, _ uint32) bool {
+func X3d(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<X3D"), []byte(`xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"`)},
 	)
 }
 
 // Amf matches an Additive Manufacturing XML file.
-func Amf(raw []byte, _ uint32) bool {
+func Amf(f *File) bool {
 	return xml(raw, xmlSig{[]byte("<amf"), []byte{}})
 }
 
 // Threemf matches a 3D Manufacturing Format file.
-func Threemf(raw []byte, _ uint32) bool {
+func Threemf(f *File) bool {
 	return xml(raw,
 		xmlSig{[]byte("<model"), []byte(`xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"`)},
 	)
 }
 
 // Xfdf matches a XML Forms Data Format file.
-func Xfdf(raw []byte, _ uint32) bool {
+func Xfdf(f *File) bool {
 	return xml(raw, xmlSig{[]byte("<xfdf"), []byte(`xmlns="http://ns.adobe.com/xfdf/"`)})
 }
 
 // VCard matches a Virtual Contact File.
-func VCard(raw []byte, _ uint32) bool {
+func VCard(f *File) bool {
 	return ciPrefix(raw, []byte("BEGIN:VCARD\n"), []byte("BEGIN:VCARD\r\n"))
 }
 
 // ICalendar matches a iCalendar file.
-func ICalendar(raw []byte, _ uint32) bool {
+func ICalendar(f *File) bool {
 	return ciPrefix(raw, []byte("BEGIN:VCALENDAR\n"), []byte("BEGIN:VCALENDAR\r\n"))
 }
-func phpPageF(raw []byte, _ uint32) bool {
+func phpPageF(f *File) bool {
 	return ciPrefix(raw,
 		[]byte("<?PHP"),
 		[]byte("<?\n"),
@@ -147,7 +147,7 @@ func phpPageF(raw []byte, _ uint32) bool {
 		[]byte("<? "),
 	)
 }
-func phpScriptF(raw []byte, _ uint32) bool {
+func phpScriptF(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS,
 		[]byte("/usr/local/bin/php"),
@@ -158,7 +158,7 @@ func phpScriptF(raw []byte, _ uint32) bool {
 }
 
 // Js matches a Javascript file.
-func Js(raw []byte, _ uint32) bool {
+func Js(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS,
 		[]byte("/bin/node"),
@@ -173,7 +173,7 @@ func Js(raw []byte, _ uint32) bool {
 }
 
 // Lua matches a Lua programming language file.
-func Lua(raw []byte, _ uint32) bool {
+func Lua(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/lua"),
@@ -184,7 +184,7 @@ func Lua(raw []byte, _ uint32) bool {
 }
 
 // Perl matches a Perl programming language file.
-func Perl(raw []byte, _ uint32) bool {
+func Perl(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/usr/bin/perl"),
@@ -194,7 +194,7 @@ func Perl(raw []byte, _ uint32) bool {
 }
 
 // Python matches a Python programming language file.
-func Python(raw []byte, _ uint32) bool {
+func Python(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS,
 		[]byte("/usr/bin/python"),
@@ -214,7 +214,7 @@ func Python(raw []byte, _ uint32) bool {
 }
 
 // Ruby matches a Ruby programming language file.
-func Ruby(raw []byte, _ uint32) bool {
+func Ruby(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS,
 		[]byte("/usr/bin/ruby"),
@@ -225,7 +225,7 @@ func Ruby(raw []byte, _ uint32) bool {
 }
 
 // Tcl matches a Tcl programming language file.
-func Tcl(raw []byte, _ uint32) bool {
+func Tcl(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS,
 		[]byte("/usr/bin/tcl"),
@@ -244,12 +244,12 @@ func Tcl(raw []byte, _ uint32) bool {
 }
 
 // Rtf matches a Rich Text Format file.
-func Rtf(raw []byte, _ uint32) bool {
+func Rtf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("{\\rtf"))
 }
 
 // Shell matches a shell script file.
-func Shell(raw []byte, _ uint32) bool {
+func Shell(f *File) bool {
 	return shebang(raw,
 		scan.CompactWS|scan.FullWord,
 		[]byte("/bin/sh"),
@@ -284,7 +284,7 @@ func Shell(raw []byte, _ uint32) bool {
 //
 // TODO: This function does not parse BOM-less UTF16 and UTF32 files. Not really
 // sure it should. Linux file utility also requires a BOM for UTF16 and UTF32.
-func Text(raw []byte, _ uint32) bool {
+func Text(f *File) bool {
 	// First look for BOM.
 	if cset := charset.FromBOM(raw); cset != "" {
 		return true
@@ -303,7 +303,7 @@ func Text(raw []byte, _ uint32) bool {
 }
 
 // XHTML matches an XHTML file. This check depends on the XML check to have passed.
-func XHTML(raw []byte, limit uint32) bool {
+func XHTML(f *File) bool {
 	raw = raw[:min(len(raw), 1024)]
 	b := scan.Bytes(raw)
 	i, _ := b.Search([]byte("<!DOCTYPE HTML"), scan.CompactWS|scan.IgnoreCase)
@@ -315,7 +315,7 @@ func XHTML(raw []byte, limit uint32) bool {
 }
 
 // Php matches a PHP: Hypertext Preprocessor file.
-func Php(raw []byte, limit uint32) bool {
+func Php(f *File) bool {
 	if res := phpPageF(raw, limit); res {
 		return res
 	}
@@ -323,7 +323,7 @@ func Php(raw []byte, limit uint32) bool {
 }
 
 // JSON matches a JavaScript Object Notation file.
-func JSON(raw []byte, limit uint32) bool {
+func JSON(f *File) bool {
 	// #175 A single JSON string, number or bool is not considered JSON.
 	// JSON objects and arrays are reported as JSON.
 	return jsonHelper(raw, limit, json.QueryNone, json.TokObject|json.TokArray)
@@ -333,13 +333,13 @@ func JSON(raw []byte, limit uint32) bool {
 //
 // GeoJSON detection implies searching for key:value pairs like: `"type": "Feature"`
 // in the input.
-func GeoJSON(raw []byte, limit uint32) bool {
+func GeoJSON(f *File) bool {
 	return jsonHelper(raw, limit, json.QueryGeo, json.TokObject)
 }
 
 // HAR matches a HAR Spec file.
 // Spec: http://www.softwareishard.com/blog/har-12-spec/
-func HAR(raw []byte, limit uint32) bool {
+func HAR(f *File) bool {
 	return jsonHelper(raw, limit, json.QueryHAR, json.TokObject)
 }
 
@@ -348,11 +348,11 @@ func HAR(raw []byte, limit uint32) bool {
 //
 // [glTF specification]: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html
 // [IANA glTF entry]: https://www.iana.org/assignments/media-types/model/gltf+json
-func GLTF(raw []byte, limit uint32) bool {
+func GLTF(f *File) bool {
 	return jsonHelper(raw, limit, json.QueryGLTF, json.TokObject)
 }
 
-func jsonHelper(raw []byte, limit uint32, q string, wantTok int) bool {
+func jsonHelper(f *File, q string, wantTok int) bool {
 	if !json.LooksLikeObjectOrArray(raw) {
 		return false
 	}
@@ -376,7 +376,7 @@ func jsonHelper(raw []byte, limit uint32, q string, wantTok int) bool {
 // NdJSON matches a Newline delimited JSON file. All complete lines from raw
 // must be valid JSON documents meaning they contain one of the valid JSON data
 // types.
-func NdJSON(raw []byte, limit uint32) bool {
+func NdJSON(f *File) bool {
 	lCount, objOrArr := 0, 0
 
 	s := scan.Bytes(raw)
@@ -398,7 +398,7 @@ func NdJSON(raw []byte, limit uint32) bool {
 }
 
 // Svg matches a SVG file.
-func Svg(raw []byte, limit uint32) bool {
+func Svg(f *File) bool {
 	return svgWithoutXMLDeclaration(raw) || svgWithXMLDeclaration(raw)
 }
 
@@ -470,7 +470,7 @@ func svgWithXMLDeclaration(s scan.Bytes) bool {
 }
 
 // Srt matches a SubRip file.
-func Srt(raw []byte, _ uint32) bool {
+func Srt(f *File) bool {
 	s := scan.Bytes(raw)
 	line := s.Line()
 
@@ -514,7 +514,7 @@ func Srt(raw []byte, _ uint32) bool {
 
 // Vtt matches a Web Video Text Tracks (WebVTT) file. See
 // https://www.iana.org/assignments/media-types/text/vtt.
-func Vtt(raw []byte, limit uint32) bool {
+func Vtt(f *File) bool {
 	// Prefix match.
 	prefixes := [][]byte{
 		{0xEF, 0xBB, 0xBF, 0x57, 0x45, 0x42, 0x56, 0x54, 0x54, 0x0A}, // UTF-8 BOM, "WEBVTT" and a line feed

--- a/internal/magic/text_csv.go
+++ b/internal/magic/text_csv.go
@@ -6,13 +6,13 @@ import (
 )
 
 // CSV matches a comma-separated values file.
-func CSV(raw []byte, limit uint32) bool {
-	return sv(raw, ',', limit)
+func CSV(f *File) bool {
+	return sv(f.Head, ',', limit)
 }
 
 // TSV matches a tab-separated values file.
-func TSV(raw []byte, limit uint32) bool {
-	return sv(raw, '\t', limit)
+func TSV(f *File) bool {
+	return sv(f.Head, '\t', limit)
 }
 
 func sv(in []byte, comma byte, limit uint32) bool {

--- a/internal/magic/text_csv.go
+++ b/internal/magic/text_csv.go
@@ -7,12 +7,12 @@ import (
 
 // CSV matches a comma-separated values file.
 func CSV(f *File) bool {
-	return sv(f.Head, ',', limit)
+	return sv(f.Head, ',', f.ReadLimit)
 }
 
 // TSV matches a tab-separated values file.
 func TSV(f *File) bool {
-	return sv(f.Head, '\t', limit)
+	return sv(f.Head, '\t', f.ReadLimit)
 }
 
 func sv(in []byte, comma byte, limit uint32) bool {

--- a/internal/magic/video.go
+++ b/internal/magic/video.go
@@ -6,12 +6,12 @@ import (
 
 // Flv matches a Flash video file.
 func Flv(f *File) bool {
-	return bytes.HasPrefix(raw, []byte("\x46\x4C\x56\x01"))
+	return bytes.HasPrefix(f.Head, []byte("\x46\x4C\x56\x01"))
 }
 
 // Asf matches an Advanced Systems Format file.
 func Asf(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{
+	return bytes.HasPrefix(f.Head, []byte{
 		0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11,
 		0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C,
 	})
@@ -19,17 +19,17 @@ func Asf(f *File) bool {
 
 // Rmvb matches a RealMedia Variable Bitrate file.
 func Rmvb(f *File) bool {
-	return bytes.HasPrefix(raw, []byte{0x2E, 0x52, 0x4D, 0x46})
+	return bytes.HasPrefix(f.Head, []byte{0x2E, 0x52, 0x4D, 0x46})
 }
 
 // WebM matches a WebM file.
 func WebM(f *File) bool {
-	return isMatroskaFileTypeMatched(raw, "webm")
+	return isMatroskaFileTypeMatched(f.Head, "webm")
 }
 
 // Mkv matches a mkv file.
 func Mkv(f *File) bool {
-	return isMatroskaFileTypeMatched(raw, "matroska")
+	return isMatroskaFileTypeMatched(f.Head, "matroska")
 }
 
 // isMatroskaFileTypeMatched is used for webm and mkv file matching.
@@ -79,13 +79,13 @@ func vintWidth(v int) int {
 
 // Mpeg matches a Moving Picture Experts Group file.
 func Mpeg(f *File) bool {
-	return len(raw) > 3 && bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x01}) &&
-		raw[3] >= 0xB0 && raw[3] <= 0xBF
+	return len(f.Head) > 3 && bytes.HasPrefix(f.Head, []byte{0x00, 0x00, 0x01}) &&
+		f.Head[3] >= 0xB0 && f.Head[3] <= 0xBF
 }
 
 // Avi matches an Audio Video Interleaved file.
 func Avi(f *File) bool {
-	return len(raw) > 16 &&
-		bytes.Equal(raw[:4], []byte("RIFF")) &&
-		bytes.Equal(raw[8:16], []byte("AVI LIST"))
+	return len(f.Head) > 16 &&
+		bytes.Equal(f.Head[:4], []byte("RIFF")) &&
+		bytes.Equal(f.Head[8:16], []byte("AVI LIST"))
 }

--- a/internal/magic/video.go
+++ b/internal/magic/video.go
@@ -5,12 +5,12 @@ import (
 )
 
 // Flv matches a Flash video file.
-func Flv(raw []byte, _ uint32) bool {
+func Flv(f *File) bool {
 	return bytes.HasPrefix(raw, []byte("\x46\x4C\x56\x01"))
 }
 
 // Asf matches an Advanced Systems Format file.
-func Asf(raw []byte, _ uint32) bool {
+func Asf(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{
 		0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11,
 		0xA6, 0xD9, 0x00, 0xAA, 0x00, 0x62, 0xCE, 0x6C,
@@ -18,17 +18,17 @@ func Asf(raw []byte, _ uint32) bool {
 }
 
 // Rmvb matches a RealMedia Variable Bitrate file.
-func Rmvb(raw []byte, _ uint32) bool {
+func Rmvb(f *File) bool {
 	return bytes.HasPrefix(raw, []byte{0x2E, 0x52, 0x4D, 0x46})
 }
 
 // WebM matches a WebM file.
-func WebM(raw []byte, limit uint32) bool {
+func WebM(f *File) bool {
 	return isMatroskaFileTypeMatched(raw, "webm")
 }
 
 // Mkv matches a mkv file.
-func Mkv(raw []byte, limit uint32) bool {
+func Mkv(f *File) bool {
 	return isMatroskaFileTypeMatched(raw, "matroska")
 }
 
@@ -78,13 +78,13 @@ func vintWidth(v int) int {
 }
 
 // Mpeg matches a Moving Picture Experts Group file.
-func Mpeg(raw []byte, limit uint32) bool {
+func Mpeg(f *File) bool {
 	return len(raw) > 3 && bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x01}) &&
 		raw[3] >= 0xB0 && raw[3] <= 0xBF
 }
 
 // Avi matches an Audio Video Interleaved file.
-func Avi(raw []byte, limit uint32) bool {
+func Avi(f *File) bool {
 	return len(raw) > 16 &&
 		bytes.Equal(raw[:4], []byte("RIFF")) &&
 		bytes.Equal(raw[8:16], []byte("AVI LIST"))

--- a/internal/magic/zip.go
+++ b/internal/magic/zip.go
@@ -7,67 +7,67 @@ import (
 )
 
 // Odt matches an OpenDocument Text file.
-func Odt(raw []byte, _ uint32) bool {
+func Odt(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.text"), 30)
 }
 
 // Ott matches an OpenDocument Text Template file.
-func Ott(raw []byte, _ uint32) bool {
+func Ott(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.text-template"), 30)
 }
 
 // Ods matches an OpenDocument Spreadsheet file.
-func Ods(raw []byte, _ uint32) bool {
+func Ods(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.spreadsheet"), 30)
 }
 
 // Ots matches an OpenDocument Spreadsheet Template file.
-func Ots(raw []byte, _ uint32) bool {
+func Ots(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.spreadsheet-template"), 30)
 }
 
 // Odp matches an OpenDocument Presentation file.
-func Odp(raw []byte, _ uint32) bool {
+func Odp(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.presentation"), 30)
 }
 
 // Otp matches an OpenDocument Presentation Template file.
-func Otp(raw []byte, _ uint32) bool {
+func Otp(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.presentation-template"), 30)
 }
 
 // Odg matches an OpenDocument Drawing file.
-func Odg(raw []byte, _ uint32) bool {
+func Odg(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.graphics"), 30)
 }
 
 // Otg matches an OpenDocument Drawing Template file.
-func Otg(raw []byte, _ uint32) bool {
+func Otg(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.graphics-template"), 30)
 }
 
 // Odf matches an OpenDocument Formula file.
-func Odf(raw []byte, _ uint32) bool {
+func Odf(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.formula"), 30)
 }
 
 // Odc matches an OpenDocument Chart file.
-func Odc(raw []byte, _ uint32) bool {
+func Odc(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.oasis.opendocument.chart"), 30)
 }
 
 // Epub matches an EPUB file.
-func Epub(raw []byte, _ uint32) bool {
+func Epub(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/epub+zip"), 30)
 }
 
 // Sxc matches an OpenOffice Spreadsheet file.
-func Sxc(raw []byte, _ uint32) bool {
+func Sxc(f *File) bool {
 	return offset(raw, []byte("mimetypeapplication/vnd.sun.xml.calc"), 30)
 }
 
 // Zip matches a zip archive.
-func Zip(raw []byte, limit uint32) bool {
+func Zip(f *File) bool {
 	return len(raw) > 3 &&
 		raw[0] == 0x50 && raw[1] == 0x4B &&
 		(raw[2] == 0x3 || raw[2] == 0x5 || raw[2] == 0x7) &&
@@ -83,7 +83,7 @@ func Zip(raw []byte, limit uint32) bool {
 // for both executable and non-executable versions. But the traversing zip entries
 // is unreliable because it does linear search for signatures
 // (instead of relying on offsets told by the file.)
-func Jar(raw []byte, limit uint32) bool {
+func Jar(f *File) bool {
 	return executableJar(raw) ||
 		zipHas(raw, zipEntries{{
 			name: []byte("META-INF/MANIFEST.MF"),
@@ -93,7 +93,7 @@ func Jar(raw []byte, limit uint32) bool {
 }
 
 // KMZ matches a zipped KML file, which is "doc.kml" by convention.
-func KMZ(raw []byte, _ uint32) bool {
+func KMZ(f *File) bool {
 	return zipHas(raw, zipEntries{{
 		name: []byte("doc.kml"),
 	}}, 100)
@@ -207,7 +207,7 @@ func (i *zipIterator) next() []byte {
 
 // APK matches an Android Package Archive.
 // The source of signatures is https://github.com/file/file/blob/1778642b8ba3d947a779a36fcd81f8e807220a19/magic/Magdir/archive#L1820-L1887
-func APK(raw []byte, _ uint32) bool {
+func APK(f *File) bool {
 	return zipHas(raw, zipEntries{{
 		name: []byte("AndroidManifest.xml"),
 	}, {

--- a/internal/magic/zip_test.go
+++ b/internal/magic/zip_test.go
@@ -131,10 +131,11 @@ func TestZeroZip(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			docx := Docx(buf.Bytes(), 0)
-			xlsx := Xlsx(buf.Bytes(), 0)
-			pptx := Pptx(buf.Bytes(), 0)
-			jar := Jar(buf.Bytes(), 0)
+			f := File{Head: buf.Bytes()}
+			docx := Docx(&f)
+			xlsx := Xlsx(&f)
+			pptx := Pptx(&f)
+			jar := Jar(&f)
 
 			if tc.docx != docx || tc.xlsx != xlsx || tc.pptx != pptx || tc.jar != jar {
 				t.Errorf(`
@@ -150,10 +151,11 @@ expected %t	%t	%t	%t;
 				t.Fatal(err)
 			}
 
-			docx = Docx(uncompressedZip.Bytes(), 0)
-			xlsx = Xlsx(uncompressedZip.Bytes(), 0)
-			pptx = Pptx(uncompressedZip.Bytes(), 0)
-			jar = Jar(uncompressedZip.Bytes(), 0)
+			f = File{Head: uncompressedZip.Bytes()}
+			docx = Docx(&f)
+			xlsx = Xlsx(&f)
+			pptx = Pptx(&f)
+			jar = Jar(&f)
 
 			if docx || xlsx || pptx || jar {
 				t.Errorf(`

--- a/mimetype.go
+++ b/mimetype.go
@@ -10,6 +10,8 @@ import (
 	"mime"
 	"os"
 	"sync/atomic"
+
+	"github.com/gabriel-vasile/mimetype/internal/magic"
 )
 
 const defaultLimit uint32 = 3072
@@ -29,7 +31,10 @@ func Detect(in []byte) *MIME {
 	}
 	mu.RLock()
 	defer mu.RUnlock()
-	return root.match(in, l)
+	return root.match(&magic.File{
+		Head:      in,
+		ReadLimit: l,
+	})
 }
 
 // DetectReader returns the MIME type of the provided reader.
@@ -67,7 +72,10 @@ func DetectReader(r io.Reader) (*MIME, error) {
 
 	mu.RLock()
 	defer mu.RUnlock()
-	return root.match(in, l), nil
+	return root.match(&magic.File{
+		Head:      in,
+		ReadLimit: l,
+	}), nil
 }
 
 // DetectFile returns the MIME type of the provided file.

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -109,7 +109,9 @@ a,"b`,
 	{"flac", "\x66\x4C\x61\x43\x00\x00\x00\x22", "audio/flac", one},
 	{"flv", "\x46\x4C\x56\x01", "video/x-flv", one},
 	{"gbr", offset(20, "GIMP"), "image/x-gimp-gbr", one},
-	{"geojson", `{"type":"Feature"}`, "application/geo+json", one},
+	// none for benchmark because geojson detector requires the JSON detector to
+	// have previously run.
+	{"geojson", `{"type":"Feature"}`, "application/geo+json", none},
 	{"geojson with space", `{ "type" : "Feature" }`, "application/geo+json", none},
 	{"gltf1", `{"asset":{"version":"1.0"}}`, "model/gltf+json", none},
 	{"gltf2", `{"asset":{"version":"2.0"}}`, "model/gltf+json", none},

--- a/tree.go
+++ b/tree.go
@@ -16,7 +16,7 @@ import (
 // When a detector passes the check, the children detectors
 // are tried in order to find a more accurate MIME type.
 var root = newMIME("application/octet-stream", "",
-	func([]byte, uint32) bool { return true },
+	func(*magic.File) bool { return true },
 	xpm, sevenZ, zip, pdf, fdf, ole, ps, psd, p7s, ogg, png, jpg, jxl, jp2, jpx,
 	jpm, jxs, gif, webp, exe, elf, ar, tar, xar, bz2, fits, tiff, bmp, lotus, ico,
 	mp3, flac, midi, ape, musePack, amr, wav, aiff, au, mpeg, quickTime, mp4, webM,
@@ -32,7 +32,7 @@ var root = newMIME("application/octet-stream", "",
 // errMIME is returned from Detect functions when err is not nil.
 // Detect could return root for erroneous cases, but it needs to lock mu in order to do so.
 // errMIME is same as root but it does not require locking.
-var errMIME = newMIME("application/octet-stream", "", func([]byte, uint32) bool { return false })
+var errMIME = newMIME("application/octet-stream", "", func(*magic.File) bool { return false })
 
 // mu guards access to the root MIME tree. Access to root must be synchronized with this lock.
 var mu = &sync.RWMutex{}


### PR DESCRIPTION
all: pass a struct to detection functions
Previously, just a []byte was passed and that made it impossible for
detection functions to share any information between them. From now on,
they will receive a *magic.File which contains the file contents but
also allows detectors to save "file facts" that will help other
detectors.

json: use file facts to reduce JSON parsing
Previously, GLTF, HAR and GeoJSON would completely parse the input and
look for the JSON fields that they are interested in. After this change,
the input is parsed one time and all the interesting fields are stored
in the magic.File facts.


Results of this code change:
JSON does not need to be parsed several times over, but that good part is offset by the `f *magic.File` that is passed between detection functions escapes to heap and causes many more allocs.
```
before:
BenchmarkAllTogether-8   	    1166	   1040947 ns/op	    4605 B/op	      68 allocs/op
after:
BenchmarkAllTogether-8   	    1107	   1044161 ns/op	   20151 B/op	     551 allocs/op
```