### PR TITLE
msoxml: match files and directories for first zip entry

### DIFF
--- a/internal/magic/zip.go
+++ b/internal/magic/zip.go
@@ -167,11 +167,11 @@ func msoxml(raw scan.Bytes, searchFor zipEntries, stopAfter int) bool {
 		// If the first is not one of the next usually expected entries,
 		// then abort this check.
 		if i == 0 {
-			if !bytes.Equal(f, []byte("[Content_Types].xml")) &&
-				!bytes.Equal(f, []byte("_rels/.rels")) &&
-				!bytes.Equal(f, []byte("docProps")) &&
-				!bytes.Equal(f, []byte("customXml")) &&
-				!bytes.Equal(f, []byte("[trash]")) {
+			if !bytes.Equal(f, []byte("[Content_Types].xml")) && // this is a file
+				!bytes.HasPrefix(f, []byte("_rels/")) && // these are directories
+				!bytes.HasPrefix(f, []byte("docProps/")) &&
+				!bytes.HasPrefix(f, []byte("customXml/")) &&
+				!bytes.HasPrefix(f, []byte("[trash]/")) {
 				return false
 			}
 		}

--- a/internal/magic/zip_test.go
+++ b/internal/magic/zip_test.go
@@ -54,40 +54,40 @@ func TestZeroZip(t *testing.T) {
 		name:  "empty zip",
 		files: nil,
 	}, {
-		name:  "no customXml",
+		name:  "no customXml/",
 		files: []string{"foo", "word/"},
 	}, {
-		name:  "customXml, but no word/",
-		files: []string{"customXml"},
+		name:  "customXml/, but no word/",
+		files: []string{"customXml/"},
 	}, {
-		name:  "customXml, and other files, but no word/",
-		files: []string{"customXml", "1", "2", "3"},
+		name:  "customXml/, and other files, but no word/",
+		files: []string{"customXml/", "1", "2", "3"},
 	}, {
-		name:  "customXml, and other files, but word/ is the 7th file", // we only check until 6th file
-		files: []string{"customXml", "1", "2", "3", "4", "5", "word/"},
+		name:  "customXml/, and other files, but word/ is the 7th file", // we only check until 6th file
+		files: []string{"customXml/", "1", "2", "3", "4", "5", "word/"},
 		docx:  true,
 	}, {
-		name:  "customXml, word/ xl/ pptx/ after 5 files",
-		files: []string{"1", "2", "3", "4", "5", "customXml", "word/", "xl/", "ppt/"},
+		name:  "customXml/, word/ xl/ pptx/ after 5 files",
+		files: []string{"1", "2", "3", "4", "5", "customXml/", "word/", "xl/", "ppt/"},
 	}, {
-		name:  "customXml, word/",
-		files: []string{"customXml", "word/"},
+		name:  "customXml/, word/",
+		files: []string{"customXml/", "word/"},
 		docx:  true,
 	}, {
-		name:  "customXml, word/with_suffix",
-		files: []string{"customXml", "word/with_suffix"},
+		name:  "customXml/, word/with_suffix",
+		files: []string{"customXml/", "word/with_suffix"},
 		docx:  true,
 	}, {
-		name:  "customXml, word/",
-		files: []string{"customXml", "word/media"},
+		name:  "customXml/, word/",
+		files: []string{"customXml/", "word/media"},
 		docx:  true,
 	}, {
-		name:  "customXml, xl/",
-		files: []string{"customXml", "xl/media"},
+		name:  "customXml/, xl/",
+		files: []string{"customXml/", "xl/media"},
 		xlsx:  true,
 	}, {
-		name:  "customXml, ppt/",
-		files: []string{"customXml", "ppt/media"},
+		name:  "customXml/, ppt/",
+		files: []string{"customXml/", "ppt/media"},
 		pptx:  true,
 	}, {
 		name:  "manifest file first",
@@ -122,6 +122,15 @@ func TestZeroZip(t *testing.T) {
 			"ppt/_rels/presentation.xml.rel",
 		},
 		pptx: true,
+	}, {
+		// #728 - msoxml directories have to be compared with bytes.HasPrefix.
+		// bytes.Equal worked fine for most office files because [Content_Types].xml
+		// is a file. But for directories, sometimes the zip record is an empty
+		// file, other times it is a file in that directory. To account for these
+		// cases, bytes.HasPrefix is used.
+		name:  "docProps dir (not file) is first",
+		files: []string{"docProps/custom.xml", "xl/"},
+		xlsx:  true,
 	}}
 
 	for i, tc := range tcases {


### PR DESCRIPTION
Previously, bytes.Equal was used for comparing first entry from the zip. 
That worked most of the times (because [Content_Types].xml, i.e. a file, not a dir)
 is the first entry in the zip. But for docProps, customXml, etc. 
the check was failing because those are directories. 

The failing check was, for example, bytes.Equal("docProps/app.xml", "docProps").

Closes #728

[mimetype_tests shows 8 more files are correctly identified](https://github.com/gabriel-vasile/mimetype_tests/actions/runs/18879132456/job/53876991140#step:7:37) after this change.
