### PR TITLE
ndjson: fix inputs truncated on the second line

### DIFF
--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -387,7 +387,6 @@ func NdJSON(raw []byte, limit uint32) bool {
 	lCount, objOrArr := 0, 0
 
 	s := scan.Bytes(raw)
-	s.DropLastLine(limit)
 	var l scan.Bytes
 	for len(s) != 0 {
 		l = s.Line()


### PR DESCRIPTION
Previously, when the input was truncated on the second line, that second line would be completely discarded from inspection. This commit makes incomplete lines count towards the ndjson line counter.

Fixed #744