### PR TITLE
MP3: add a frame parser and do linear search for headers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,3 +33,4 @@ jobs:
     - run: go test -fuzztime=3m -fuzz=Meta            ./internal/charset
     - run: go test -fuzztime=3m -fuzz=GetAnAttribute  ./internal/markup
     - run: go test -fuzztime=3m -fuzz=GetAValue       ./internal/markup
+    - run: go test -fuzztime=3m -fuzz=ExtractFrame    ./internal/mp3

--- a/internal/magic/audio.go
+++ b/internal/magic/audio.go
@@ -3,6 +3,8 @@ package magic
 import (
 	"bytes"
 	"encoding/binary"
+
+	"github.com/gabriel-vasile/mimetype/internal/mp3"
 )
 
 // Flac matches a Free Lossless Audio Codec file.
@@ -65,20 +67,41 @@ func Mp3(raw []byte, limit uint32) bool {
 		return true
 	}
 
-	// Match MP3 files without tags
+	// If no ID3v2 tag found, then we will look for MP3 frames, but:
+	// a. Layer III files are a lot more prevalent than Layer I and II.
+	// b. Layer I frame header has looser constraints than the others: many files
+	// with regularly repeating 0xFFFF bytes can be misidentified as MP3.
+	// c. MP3 files are composed of individual frames and those frames can have
+	// leading garbage bytes: if we want to find all valid MP3s, we have to do a
+	// linear search. #775, #310
+	// d. There are file formats that contain MP3s inside: .mo3 and .swa
+	//
+	// Given a, b, c and d, this code:
+	// - initially tries to match by first two bytes in header
+	// - checks for .mo3 and .swa and disqualifies them
+	// - does linear search for Layer III
 	switch binary.BigEndian.Uint16(raw[:2]) & 0xFFFE {
-	case 0xFFFA:
-		// MPEG ADTS, layer III, v1
-		return true
-	case 0xFFF2:
-		// MPEG ADTS, layer III, v2
-		return true
-	case 0xFFE2:
-		// MPEG ADTS, layer III, v2.5
+	case 0xFFFA, 0xFFF2, 0xFFE2, // layer III: v1, v2, v2.5
+		0xFFFC, 0xFFF4, // layer II: v1, v2
+		0xFFF5: // layer I: v2
 		return true
 	}
+	// http://lclevy.free.fr/mo3/
+	if bytes.HasPrefix(raw, []byte("MO3")) {
+		return false
+	}
 
-	return false
+	// From PRONOM:
+	// Macromedia licensed the MP3 technology in 1995 to use in their Shockwave
+	// product. .swa or Shockwave Audio was originally added as a free plugin
+	// (Xtras) to SoundEdit 16 to export AIFF files to .swa.
+	// There is no media type assigned for .swa.
+	if bytes.HasPrefix(raw, []byte{0x00, 0x00, 0x01, 0x40, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00}) {
+		return false
+	}
+
+	_, size := mp3.ExtractFrame(raw)
+	return size > 0
 }
 
 // Based on https://id3.org/Developer%20Information.

--- a/internal/magic/audio.go
+++ b/internal/magic/audio.go
@@ -53,8 +53,8 @@ func AAC(raw []byte, _ uint32) bool {
 	return len(raw) > 1 && ((raw[0] == 0xFF && raw[1] == 0xF1) || (raw[0] == 0xFF && raw[1] == 0xF9))
 }
 
-// Mp3 matches an mp3 file.
-func Mp3(raw []byte, limit uint32) bool {
+// MP3 matches a .mp3 file.
+func MP3(raw []byte, limit uint32) bool {
 	if len(raw) < 3 {
 		return false
 	}

--- a/internal/mp3/frame.go
+++ b/internal/mp3/frame.go
@@ -1,0 +1,144 @@
+package mp3
+
+// minFreeFormatFrameBytes is the smallest frame size we accept as valid.
+// The MP3 spec's smallest non-free-format frame is MPEG-2 Layer III at
+// 8 kbps / 24 kHz = 24 bytes; anything below that cannot physically hold a
+// header plus the layer's side information and is almost certainly a false sync.
+const minFrameBytes = 24
+
+// minTruncatedSyncMatches is the minimum number of confirmed successive
+// header matches required to accept a candidate frame when the buffer ends
+// before maxFrameSyncMatches confirmations can be performed.
+const minTruncatedSyncMatches = 2
+
+func ExtractFrame(b []byte) (start, size int) {
+	limit := min(len(b), 2048+headerSize)
+	for i := 0; i < limit-headerSize; i++ {
+		hdr := header{b[i], b[i+1], b[i+2], b[i+3]}
+		if !hdr.valid() {
+			continue
+		}
+		frameBytes := hdr.frameBytes()
+		// Is this check needed? frameBytes should never be less than
+		// minFrameBytes because the header is valid at this point.
+		if frameBytes < minFrameBytes {
+			continue
+		}
+		frameAndPad := frameBytes + hdr.padding()
+
+		validHere := frameBytes > 0 && i+frameAndPad <= len(b) && matchFrame(b[i:])
+		exact := i == 0 && frameAndPad == len(b)
+		if validHere || exact {
+			return i, frameAndPad
+		}
+	}
+	return 0, 0
+}
+
+// matchFrame confirms a candidate header by stepping forward and checking that
+// subsequent headers are consistent.
+func matchFrame(buf []byte) bool {
+	// maxFrameSyncMatches limits how many valid frames we look at.
+	const maxFrameSyncMatches = 10
+	hdr := header{buf[0], buf[1], buf[2], buf[3]}
+	i := 0
+	for nmatch := 0; nmatch < maxFrameSyncMatches; nmatch++ {
+		next := header{buf[i], buf[i+1], buf[i+2], buf[i+3]}
+		i += next.frameBytes() + next.padding()
+		if i+headerSize > len(buf) {
+			return nmatch >= minTruncatedSyncMatches
+		}
+		cmp := header{buf[i], buf[i+1], buf[i+2], buf[i+3]}
+		if !hdr.compatibleWith(cmp) {
+			return false
+		}
+	}
+	return true
+}
+
+const headerSize = 4
+
+type header [headerSize]byte
+
+func (h header) isFreeFormat() bool  { return h[2]&0xF0 == 0 }
+func (h header) isMPEG1() bool       { return h[1]&0x8 != 0 }
+func (h header) isMPEG25() bool      { return h[1]&0x10 == 0 }
+func (h header) rawLayer() byte      { return h[1] >> 1 & 3 }
+func (h header) rawBitrate() byte    { return h[2] >> 4 }
+func (h header) rawSampleRate() byte { return h[2] >> 2 & 3 }
+func (h header) rawEmphasis() byte   { return h[3] & 0b11 }
+func (h header) isFrame576() bool    { return h[1]&14 == 2 }
+func (h header) padding() int {
+	if h[2]&0x2 != 0 {
+		return 1
+	}
+	return 0
+}
+
+// valid reports whether the four bytes form a syntactically valid MP3 header.
+func (h header) valid() bool {
+	return h[0] == 0xff &&
+		((h[1]&0xF0) == 0xf0 || (h[1]&0xFE) == 0xe2) &&
+		h.rawLayer() == 1 && // Layer III
+		h.rawBitrate() != 15 && // Not allowed by spec.
+		h.rawSampleRate() != 3 &&
+		h.rawEmphasis() != 2 &&
+		// The code for extracting frame size for free-format is tedious and
+		// free-format MP3s are extinct.
+		!h.isFreeFormat()
+}
+
+// compatibleWith reports whether two headers describe frames belonging to the
+// same MP3 stream — same MPEG version, layer, sample-rate index and
+// free-format flag.
+func (h header) compatibleWith(o header) bool {
+	return o.valid() &&
+		(h[1]^o[1])&0xFE == 0 &&
+		(h[2]^o[2])&0x0C == 0
+}
+
+// bitrateKbps returns the bitrate of the frame in kilobits per second.
+func (h header) bitrateKbps() int {
+	// halfrate[mpeg1?][bitrate_idx] holds bitrate/2 in kbps.
+	halfrate := [2][15]uint8{
+		{0, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80},
+		{0, 16, 20, 24, 28, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160},
+	}
+	mpeg1 := 0
+	if h.isMPEG1() {
+		mpeg1 = 1
+	}
+	return 2 * int(halfrate[mpeg1][h.rawBitrate()])
+}
+
+// sampleRateHz returns the sampling rate of the frame in Hz.
+func (h header) sampleRateHz() int {
+	base := [3]int{44100, 48000, 32000}[h.rawSampleRate()]
+	if !h.isMPEG1() {
+		base >>= 1
+	}
+	if h.isMPEG25() {
+		base >>= 1
+	}
+	return base
+}
+
+// frameSamples returns the number of audio samples per channel encoded in
+// the frame.
+func (h header) frameSamples() int {
+	if h.isFrame576() {
+		return 576
+	}
+	return 1152
+}
+
+// frameBytes returns the size of the frame body (header + side info + audio
+// data, excluding padding) in bytes.
+func (h header) frameBytes() int {
+	br := h.bitrateKbps()
+	sr := h.sampleRateHz()
+	if br == 0 || sr == 0 {
+		return 0
+	}
+	return h.frameSamples() * br * 125 / sr
+}

--- a/internal/mp3/frame.go
+++ b/internal/mp3/frame.go
@@ -1,6 +1,8 @@
 package mp3
 
-// minFreeFormatFrameBytes is the smallest frame size we accept as valid.
+import "bytes"
+
+// minFrameBytes is the smallest frame size we accept as valid.
 // The MP3 spec's smallest non-free-format frame is MPEG-2 Layer III at
 // 8 kbps / 24 kHz = 24 bytes; anything below that cannot physically hold a
 // header plus the layer's side information and is almost certainly a false sync.
@@ -14,16 +16,16 @@ const minTruncatedSyncMatches = 2
 func ExtractFrame(b []byte) (start, size int) {
 	limit := min(len(b), 2048+headerSize)
 	for i := 0; i < limit-headerSize; i++ {
+		j := bytes.IndexByte(b[i:limit-headerSize], 0xFF)
+		if j < 0 {
+			break
+		}
+		i += j
 		hdr := header{b[i], b[i+1], b[i+2], b[i+3]}
 		if !hdr.valid() {
 			continue
 		}
 		frameBytes := hdr.frameBytes()
-		// Is this check needed? frameBytes should never be less than
-		// minFrameBytes because the header is valid at this point.
-		if frameBytes < minFrameBytes {
-			continue
-		}
 		frameAndPad := frameBytes + hdr.padding()
 
 		validHere := frameBytes > 0 && i+frameAndPad <= len(b) && matchFrame(b[i:])
@@ -89,8 +91,7 @@ func (h header) valid() bool {
 }
 
 // compatibleWith reports whether two headers describe frames belonging to the
-// same MP3 stream — same MPEG version, layer, sample-rate index and
-// free-format flag.
+// same MP3 stream — same MPEG version, layer, sample-rate index.
 func (h header) compatibleWith(o header) bool {
 	return o.valid() &&
 		(h[1]^o[1])&0xFE == 0 &&

--- a/internal/mp3/frame.go
+++ b/internal/mp3/frame.go
@@ -2,12 +2,6 @@ package mp3
 
 import "bytes"
 
-// minFrameBytes is the smallest frame size we accept as valid.
-// The MP3 spec's smallest non-free-format frame is MPEG-2 Layer III at
-// 8 kbps / 24 kHz = 24 bytes; anything below that cannot physically hold a
-// header plus the layer's side information and is almost certainly a false sync.
-const minFrameBytes = 24
-
 // minTruncatedSyncMatches is the minimum number of confirmed successive
 // header matches required to accept a candidate frame when the buffer ends
 // before maxFrameSyncMatches confirmations can be performed.

--- a/internal/mp3/frame.go
+++ b/internal/mp3/frame.go
@@ -23,6 +23,8 @@ func ExtractFrame(b []byte) (start, size int) {
 		frameAndPad := frameBytes + hdr.padding()
 
 		validHere := frameBytes > 0 && i+frameAndPad <= len(b) && matchFrame(b[i:])
+		// When the buffer is exactly one frame, matchFrame cannot look ahead for
+		// a subsequent header to confirm the stream. Trust the validated header.
 		exact := i == 0 && frameAndPad == len(b)
 		if validHere || exact {
 			return i, frameAndPad
@@ -37,10 +39,8 @@ func matchFrame(buf []byte) bool {
 	// maxFrameSyncMatches limits how many valid frames we look at.
 	const maxFrameSyncMatches = 10
 	hdr := header{buf[0], buf[1], buf[2], buf[3]}
-	i := 0
+	i := hdr.frameBytes() + hdr.padding()
 	for nmatch := 0; nmatch < maxFrameSyncMatches; nmatch++ {
-		next := header{buf[i], buf[i+1], buf[i+2], buf[i+3]}
-		i += next.frameBytes() + next.padding()
 		if i+headerSize > len(buf) {
 			return nmatch >= minTruncatedSyncMatches
 		}
@@ -48,6 +48,7 @@ func matchFrame(buf []byte) bool {
 		if !hdr.compatibleWith(cmp) {
 			return false
 		}
+		i += cmp.frameBytes() + cmp.padding()
 	}
 	return true
 }

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -1,0 +1,300 @@
+package mp3
+
+import (
+	"bytes"
+	"errors"
+	"math/rand/v2"
+	"testing"
+)
+
+// buildFrame constructs a 4-byte MP3 frame header with the given parameters.
+// version: 0=MPEG2.5, 2=MPEG2, 3=MPEG1
+// layer:   1=Layer3, 2=Layer2, 3=Layer1
+// bitrateIdx: index into bitrates table (1-14 for valid)
+// sampleRateIdx: 0-2 for valid
+func buildFrame(version, layer, bitrateIdx, sampleRateIdx byte) []byte {
+	b := make([]byte, 4)
+	b[0] = 0xFF
+	b[1] = 0xE0 | (version << 3) | (layer << 1) | 0x01 // crc bit set
+	b[2] = (bitrateIdx << 4) | (sampleRateIdx << 2)
+	b[3] = 0x00 // no emphasis, stereo, not copyrighted, not original
+	return b
+}
+
+func bytesToHeader(b []byte) header {
+	return header{b[0], b[1], b[2], b[3]}
+}
+
+// buildValidMPEG1Layer3Frame builds a known-good MPEG1 Layer3 frame header.
+// MPEG1=3, Layer3=1, bitrate index 9 (128kbps), sample rate index 0 (44100Hz)
+// A real MPEG1 Layer3 frame at 128kbps/44100Hz is 417 bytes.
+// We use a smaller size for test brevity; the function only checks
+// the header of each frame, not the audio payload.
+func buildValidMPEG1Layer3Frame() []byte {
+	return buildFrame(0, 1, 1, 2)
+}
+
+// repeatFrames builds a byte slice with `count` consecutive valid frames,
+// each padded to `frameSize` bytes total. If rng, the padding values will be
+// random instead of 0x00.
+func repeatFrames(header []byte, frameSize, count int, rng bool) []byte {
+	var out []byte
+
+	r := rand.NewChaCha8([32]byte{})
+	for i := 0; i < count; i++ {
+		frame := make([]byte, frameSize)
+		if rng {
+			r.Read(frame)
+		}
+		copy(frame[:4], header)
+		if rng {
+			prepend := make([]byte, frameSize)
+			r.Read(prepend)
+			out = append(out, prepend...)
+		}
+		out = append(out, frame...)
+	}
+	return out
+}
+
+func TestExtractFrame(t *testing.T) {
+	validHeader := buildValidMPEG1Layer3Frame()
+
+	const frameSize = 72
+	// Matches how many bytes the implementation searches for.
+	const mp3MaxSearch = 2048
+
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{{
+		name: "four consecutive valid frames, no padding",
+		data: repeatFrames(validHeader, frameSize, 4, false),
+		want: true,
+	}, {
+		name: "four valid frames with leading 0x00 padding",
+		data: append(make([]byte, 100), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: true,
+	}, {
+		name: "four valid frames with leading 0xFF padding",
+		data: append(bytes.Repeat([]byte{0xFF}, 100), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: true,
+	}, {
+		name: "four valid frames with leading 2047 0x00 bytes padding",
+		data: append(bytes.Repeat([]byte{0x00}, 2047), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: true,
+	}, {
+		name: "four valid frames with leading 2048 0x00 bytes padding",
+		data: append(bytes.Repeat([]byte{0x00}, 2048), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: false,
+	}, {
+		name: "only two valid frames (below threshold)",
+		data: repeatFrames(validHeader, frameSize, 2, false),
+		want: false,
+	}, {
+		name: "empty input",
+		data: []byte{},
+		want: false,
+	}, {
+		name: "all zeros, no sync byte",
+		data: make([]byte, 1024),
+		want: false,
+	}, {
+		name: "0xFF bytes but no valid frame follows",
+		data: []byte{0xFF, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00},
+		want: false,
+	}, {
+		name: "leading padding exceeds mp3MaxSearch before first frame",
+		data: append(make([]byte, mp3MaxSearch+1), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: false,
+	}, {
+		name: "leading padding exactly at mp3MaxSearch boundary",
+		// mp3MaxSearch-4 bytes of zeros, then a valid frame starting with 0xFF
+		data: append(make([]byte, mp3MaxSearch-4), repeatFrames(validHeader, frameSize, 4, false)...),
+		want: true,
+	}, {
+		name: "4 headers with padding",
+		data: func() []byte {
+			padded := append([]byte{}, validHeader...)
+			padded[2] |= 0x2
+			return repeatFrames(padded, frameSize+1, 4, false)
+		}(),
+		want: true,
+	}, {
+		name: "11 headers to have more than maxFrameSyncMatches",
+		data: repeatFrames(validHeader, frameSize, 11, false),
+		want: true,
+	}, {
+		name: "second frame header is not valid",
+		data: func() []byte {
+			f1 := buildFrame(3, 1, 9, 0)
+			f2 := buildFrame(0, 0, 0, 0)
+			var out []byte
+			frame1 := make([]byte, bytesToHeader(f1).frameBytes())
+			copy(frame1, f1)
+			out = append(out, frame1...)
+			frame2 := make([]byte, frameSize)
+			copy(frame2, f2)
+			out = append(out, frame2...)
+			return out
+		}(),
+		want: false,
+	}, {
+		name: "mismatched second frame version",
+		// First frame: MPEG1 (version=3), second frame: MPEG2 (version=2)
+		data: func() []byte {
+			f1 := buildFrame(3, 1, 9, 0)
+			f2 := buildFrame(2, 1, 9, 0)
+			var out []byte
+			frame1 := make([]byte, bytesToHeader(f1).frameBytes())
+			copy(frame1, f1)
+			out = append(out, frame1...)
+			frame2 := make([]byte, bytesToHeader(f2).frameBytes())
+			copy(frame2, f2)
+			out = append(out, frame2...)
+			return out
+		}(),
+		want: false,
+	}, {
+		name: "invalid emphasis byte (reserved value 2)",
+		data: func() []byte {
+			h := make([]byte, 4)
+			copy(h, validHeader)
+			h[3] = 0x02 // emphasis = 2 (reserved)
+			return repeatFrames(h, frameSize, 4, false)
+		}(),
+		want: false,
+	}, {
+		name: "invalid layer (reserved value 0)",
+		data: func() []byte {
+			h := make([]byte, 4)
+			copy(h, validHeader)
+			h[1] = (h[1] & 0xF9) // layer bits = 00 (reserved)
+			return repeatFrames(h, frameSize, 4, false)
+		}(),
+		want: false,
+	}, {
+		name: "invalid version (reserved value 1)",
+		data: func() []byte {
+			h := make([]byte, 4)
+			copy(h, validHeader)
+			h[1] = (h[1] & 0xE7) | (1 << 3) // version bits = 01 (reserved)
+			return repeatFrames(h, frameSize, 4, false)
+		}(),
+		want: false,
+	}, {
+		name: "invalid sample rate index (0x03 = reserved)",
+		data: func() []byte {
+			h := make([]byte, 4)
+			copy(h, validHeader)
+			h[2] = (h[2] & 0xF0) | 0x0C // sampleRateIdx = 3
+			return repeatFrames(h, frameSize, 4, false)
+		}(),
+		want: false,
+	}, {
+		name: "invalid bitrate index (0x0F = bad)",
+		data: func() []byte {
+			h := make([]byte, 4)
+			copy(h, validHeader)
+			h[2] = (h[2] & 0x0F) | 0xF0 // bitrateIdx = 15
+			return repeatFrames(h, frameSize, 4, false)
+		}(),
+		want: false,
+	}, {
+		name: "input shorter than one frame header",
+		data: []byte{0xFF, 0xFB},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, e := ExtractFrame(tt.data)
+			if got := e != 0; got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkExtractFrame(b *testing.B) {
+	validHeader := buildValidMPEG1Layer3Frame()
+	frameSize := bytesToHeader(validHeader).frameBytes()
+
+	b.ReportAllocs()
+	b.Run("repeatFrames", func(b *testing.B) {
+		data := repeatFrames(validHeader, frameSize, 4, false)
+		data = append(data, repeatFrames(validHeader, frameSize, 4, true)...)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			ExtractFrame(data)
+		}
+	})
+
+	b.Run("random data", func(b *testing.B) {
+		largeData := make([]byte, 4096)
+		r := rand.NewChaCha8([32]byte{})
+		if _, err := r.Read(largeData); err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			ExtractFrame(largeData)
+		}
+	})
+}
+
+func FuzzExtractFrame(f *testing.F) {
+	overlapHeadOnFrame := func(head, frame []byte) {
+		for i := 0; i < 4; i++ {
+			frame[i] = head[i]
+		}
+	}
+	// Only fuzz the header of the frame, because the body is treated as arbitrary
+	// data that does not influence anything.
+	// We're not seeding the first byte of the header because it is always 0xFF.
+	h := buildValidMPEG1Layer3Frame()
+	f.Add(h[1], h[2], h[3], h[1], h[2], h[3], h[1], h[2], h[3])
+
+	frame1, frame2, frame3 := make([]byte, 1441), make([]byte, 1441), make([]byte, 1441)
+	r := rand.NewChaCha8([32]byte{})
+	_, err1 := r.Read(frame1)
+	_, err2 := r.Read(frame2)
+	_, err3 := r.Read(frame3)
+	if err := errors.Join(err1, err2, err3); err != nil {
+		f.Fatal(err)
+	}
+
+	// Allocate data only once.
+	data := make([]byte, 3*1441)
+	f.Fuzz(func(t *testing.T, h11, h12, h13, h21, h22, h23, h31, h32, h33 byte) {
+		head1 := bytesToHeader([]byte{0xFF, h11, h12, h13})
+		if !head1.valid() {
+			return
+		}
+		head2 := bytesToHeader([]byte{0xFF, h21, h22, h23})
+		if !head2.valid() {
+			head2 = head1
+		}
+		head3 := bytesToHeader([]byte{0xFF, h31, h32, h33})
+		if !head3.valid() {
+			head3 = head2
+		}
+		overlapHeadOnFrame(head1[:], frame1)
+		overlapHeadOnFrame(head2[:], frame2)
+		overlapHeadOnFrame(head3[:], frame3)
+
+		data = data[:0]
+		// Sometimes put trash bytes before and after the frames.
+		if h11%2 == 0 {
+			data = append(data, h11, h12, h13)
+		}
+		data = append(data, frame1[:head1.frameBytes()+head1.padding()]...)
+		data = append(data, frame2[:head2.frameBytes()+head2.padding()]...)
+		data = append(data, frame3[:head3.frameBytes()+head3.padding()]...)
+		if h21%2 == 0 {
+			data = append(data, h21, h22, h23)
+		}
+		ExtractFrame(data)
+	})
+}

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -25,12 +25,11 @@ func bytesToHeader(b []byte) header {
 	return header{b[0], b[1], b[2], b[3]}
 }
 
-// buildValidMPEG1Layer3Frame builds a known-good MPEG1 Layer3 frame header.
-// MPEG1=3, Layer3=1, bitrate index 9 (128kbps), sample rate index 0 (44100Hz)
-// A real MPEG1 Layer3 frame at 128kbps/44100Hz is 417 bytes.
-// We use a smaller size for test brevity; the function only checks
-// the header of each frame, not the audio payload.
-func buildValidMPEG1Layer3Frame() []byte {
+// buildValidMP3Header builds a known-good MPEG2.5 Layer3 frame header.
+// MPEG2.5 (version=0), Layer3, bitrate index 1 (8 kbps), sample rate index 2
+// (8000 Hz). That yields 72-byte frames, which is small enough to keep tests
+// fast while exercising real frame-size arithmetic.
+func buildValidMP3Header() []byte {
 	return buildFrame(0, 1, 1, 2)
 }
 
@@ -58,9 +57,9 @@ func repeatFrames(header []byte, frameSize, count int, rng bool) []byte {
 }
 
 func TestExtractFrame(t *testing.T) {
-	validHeader := buildValidMPEG1Layer3Frame()
+	validHeader := buildValidMP3Header()
+	frameSize := bytesToHeader(validHeader).frameBytes()
 
-	const frameSize = 72
 	// Matches how many bytes the implementation searches for.
 	const mp3MaxSearch = 2048
 
@@ -218,7 +217,7 @@ func TestExtractFrame(t *testing.T) {
 }
 
 func BenchmarkExtractFrame(b *testing.B) {
-	validHeader := buildValidMPEG1Layer3Frame()
+	validHeader := buildValidMP3Header()
 	frameSize := bytesToHeader(validHeader).frameBytes()
 
 	b.Run("repeatFrames", func(b *testing.B) {
@@ -254,7 +253,7 @@ func FuzzExtractFrame(f *testing.F) {
 	// Only fuzz the header of the frame, because the body is treated as arbitrary
 	// data that does not influence anything.
 	// We're not seeding the first byte of the header because it is always 0xFF.
-	h := buildValidMPEG1Layer3Frame()
+	h := buildValidMP3Header()
 	f.Add(h[1], h[2], h[3], h[1], h[2], h[3], h[1], h[2], h[3])
 
 	frame1, frame2, frame3 := make([]byte, 1441), make([]byte, 1441), make([]byte, 1441)

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -58,8 +58,8 @@ func repeatFrames(header []byte, frameSize, count int, rng bool) []byte {
 
 func TestExtractFrame(t *testing.T) {
 	validHeader := buildValidMP3Header()
-	frameSize := bytesToHeader(validHeader).frameBytes()
 
+	frameSize := 72
 	// Matches how many bytes the implementation searches for.
 	const mp3MaxSearch = 2048
 

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -130,12 +130,12 @@ func TestExtractFrame(t *testing.T) {
 		data: func() []byte {
 			f1 := buildFrame(3, 1, 9, 0)
 			f2 := buildFrame(0, 0, 0, 0)
-			var out []byte
 			frame1 := make([]byte, bytesToHeader(f1).frameBytes())
-			copy(frame1, f1)
-			out = append(out, frame1...)
 			frame2 := make([]byte, frameSize)
+			copy(frame1, f1)
 			copy(frame2, f2)
+			out := make([]byte, 0, len(frame1)+len(frame2))
+			out = append(out, frame1...)
 			out = append(out, frame2...)
 			return out
 		}(),
@@ -146,12 +146,12 @@ func TestExtractFrame(t *testing.T) {
 		data: func() []byte {
 			f1 := buildFrame(3, 1, 9, 0)
 			f2 := buildFrame(2, 1, 9, 0)
-			var out []byte
 			frame1 := make([]byte, bytesToHeader(f1).frameBytes())
-			copy(frame1, f1)
-			out = append(out, frame1...)
 			frame2 := make([]byte, bytesToHeader(f2).frameBytes())
+			copy(frame1, f1)
 			copy(frame2, f2)
+			out := make([]byte, 0, len(frame1)+len(frame2))
+			out = append(out, frame1...)
 			out = append(out, frame2...)
 			return out
 		}(),

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -44,12 +44,12 @@ func repeatFrames(header []byte, frameSize, count int, rng bool) []byte {
 	for i := 0; i < count; i++ {
 		frame := make([]byte, frameSize)
 		if rng {
-			r.Read(frame)
+			_, _ = r.Read(frame)
 		}
 		copy(frame[:4], header)
 		if rng {
 			prepend := make([]byte, frameSize)
-			r.Read(prepend)
+			_, _ = r.Read(prepend)
 			out = append(out, prepend...)
 		}
 		out = append(out, frame...)
@@ -267,7 +267,7 @@ func FuzzExtractFrame(f *testing.F) {
 	}
 
 	// Allocate data only once.
-	data := make([]byte, 3*1441)
+	data := make([]byte, 0, 3*1441)
 	f.Fuzz(func(t *testing.T, h11, h12, h13, h21, h22, h23, h31, h32, h33 byte) {
 		head1 := bytesToHeader([]byte{0xFF, h11, h12, h13})
 		if !head1.valid() {

--- a/internal/mp3/frame_test.go
+++ b/internal/mp3/frame_test.go
@@ -221,8 +221,8 @@ func BenchmarkExtractFrame(b *testing.B) {
 	validHeader := buildValidMPEG1Layer3Frame()
 	frameSize := bytesToHeader(validHeader).frameBytes()
 
-	b.ReportAllocs()
 	b.Run("repeatFrames", func(b *testing.B) {
+		b.ReportAllocs()
 		data := repeatFrames(validHeader, frameSize, 4, false)
 		data = append(data, repeatFrames(validHeader, frameSize, 4, true)...)
 		b.ResetTimer()
@@ -232,6 +232,7 @@ func BenchmarkExtractFrame(b *testing.B) {
 	})
 
 	b.Run("random data", func(b *testing.B) {
+		b.ReportAllocs()
 		largeData := make([]byte, 4096)
 		r := rand.NewChaCha8([32]byte{})
 		if _, err := r.Read(largeData); err != nil {

--- a/supported_mimes.md
+++ b/supported_mimes.md
@@ -67,7 +67,6 @@ Extension | MIME type <br> Aliases | Hierarchy
 **.bmp** | **image/bmp** <br> image/x-bmp, image/x-ms-bmp | bmp>root
 **.123** | **application/vnd.lotus-1-2-3** | 123>root
 **.ico** | **image/x-icon** | ico>root
-**.mp3** | **audio/mpeg** <br> audio/x-mpeg, audio/mp3 | mp3>root
 **.flac** | **audio/flac** | flac>root
 **.midi** | **audio/midi** <br> audio/mid, audio/sp-midi, audio/x-mid, audio/x-midi | midi>root
 **.ape** | **audio/ape** | ape>root
@@ -159,6 +158,7 @@ Extension | MIME type <br> Aliases | Hierarchy
 **.fm** | **application/vnd.framemaker** | fm>root
 **.bufr** | **application/bufr** | bufr>root
 **.pyc** | **application/x-bytecode.python** | pyc>root
+**.mp3** | **audio/mpeg** <br> audio/x-mpeg, audio/mp3 | mp3>root
 **.txt** | **text/plain** | txt>root
 **.svg** | **image/svg+xml** | svg>txt>root
 **.html** | **text/html** | html>txt>root

--- a/tree.go
+++ b/tree.go
@@ -19,12 +19,16 @@ var root = newMIME("application/octet-stream", "",
 	func([]byte, uint32) bool { return true },
 	xpm, sevenZ, zip, pdf, fdf, ole, ps, psd, p7s, ogg, png, jpg, jxl, jp2, jpx,
 	jpm, jxs, gif, webp, exe, elf, ar, tar, xar, bz2, fits, tiff, bmp, lotus, ico,
-	mp3, flac, midi, ape, musePack, amr, wav, aiff, au, mpeg, quickTime, mp4, webM,
+	flac, midi, ape, musePack, amr, wav, aiff, au, mpeg, quickTime, mp4, webM,
 	avi, flv, mkv, asf, aac, voc, m3u, rmvb, gzip, class, swf, crx, ttf, woff,
 	woff2, otf, ttc, eot, wasm, shx, dbf, dcm, rar, djvu, mobi, lit, bpg, cbor,
 	sqlite3, dwg, nes, lnk, macho, qcp, icns, hdr, mrc, mdb, accdb, zstd, cab,
 	rpm, xz, lzip, torrent, cpio, tzif, xcf, pat, gbr, glb, cabIS, jxr, parquet,
 	oneNote, chm, wpd, dxf, grib, zlib, inf, hlp, fm, bufr, pyc,
+	// MP3 is late because it does a linear search in the input. That means
+	// containers that embed an MP3, for example: an mp4 file, or a zip without
+	// compression, would pass as MP3s.
+	mp3,
 	// Keep text last because it is the slowest check.
 	text,
 )

--- a/tree.go
+++ b/tree.go
@@ -164,7 +164,7 @@ var (
 	heifSeq = newMIME("image/heif-sequence", ".heif", magic.HeifSequence)
 	hdr     = newMIME("image/vnd.radiance", ".hdr", magic.Hdr)
 	avif    = newMIME("image/avif", ".avif", magic.AVIF)
-	mp3     = newMIME("audio/mpeg", ".mp3", magic.Mp3).
+	mp3     = newMIME("audio/mpeg", ".mp3", magic.MP3).
 		alias("audio/x-mpeg", "audio/mp3")
 	flac = newMIME("audio/flac", ".flac", magic.Flac)
 	midi = newMIME("audio/midi", ".midi", magic.Midi).


### PR DESCRIPTION
```go
	// If no ID3v2 tag found, then we will look for MP3 frames, but:
	// a. Layer III files are a lot more prevalent than Layer I and II.
	// b. Layer I frame header has looser constraints than the others: many files
	// with regularly repeating 0xFFFF bytes can be misidentified as MP3.
	// c. MP3 files are composed of individual frames and those frames can have
	// leading garbage bytes: if we want to find all valid MP3s, we have to do a
	// linear search. #775, #310
	// d. There are file formats that contain MP3s inside: .mo3 and .swa
	//
	// Given a, b, c and d, this code:
	// - initially tries to match by first two bytes in header
	// - checks for .mo3 and .swa and disqualifies them
	// - does linear search for Layer III
```