### PR TITLE
fix: detect RTF files with trailing null bytes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -26,7 +26,9 @@ var root = newMIME("application/octet-stream", "",
 	rpm, xz, lzip, torrent, cpio, tzif, xcf, pat, gbr, glb, cabIS, jxr, parquet,
 	oneNote, chm, wpd, dxf, grib, zlib, inf, hlp, fm, bufr, pyc,
 	// Keep text last because it is the slowest check.
-	text,
+	// RTF is checked before text because some RTF files have trailing
+	// null bytes (from Wordpad/Word) which fail the text binary check.
+	rtf, text,
 )
 
 // errMIME is returned from Detect functions when err is not nil.
@@ -82,7 +84,7 @@ var (
 		alias("application/x-ogg")
 	oggAudio = newMIME("audio/ogg", ".oga", magic.OggAudio)
 	oggVideo = newMIME("video/ogg", ".ogv", magic.OggVideo)
-	text     = newMIME("text/plain", ".txt", magic.Text, svg, html, xml, php, js, lua, perl, python, ruby, json, ndJSON, rtf, srt, tcl, csv, tsv, vCard, iCalendar, warc, vtt, shell, netpbm, netpgm, netppm, netpam, rfc822)
+	text     = newMIME("text/plain", ".txt", magic.Text, svg, html, xml, php, js, lua, perl, python, ruby, json, ndJSON, srt, tcl, csv, tsv, vCard, iCalendar, warc, vtt, shell, netpbm, netpgm, netppm, netpam, rfc822)
 	xml      = newMIME("text/xml", ".xml", magic.XML, rss, atom, x3d, kml, xliff, collada, gml, gpx, tcx, amf, threemf, xfdf, owl2, xhtml, cdxxml).
 			alias("application/xml")
 	xhtml   = newMIME("application/xhtml+xml", ".html", magic.XHTML)


### PR DESCRIPTION
Fixes #760

## Problem

Wordpad and Microsoft Word sometimes append a trailing `0x00` byte to RTF files. Since RTF is a child of `text/plain` in the MIME tree, the text binary-data check (per WHATWG spec, `0x00` is a binary byte) rejects these files before the RTF detector runs. Result: valid RTF files are classified as `application/octet-stream`.

## Fix

Move RTF from being a child of `text/plain` to a root-level detector. RTF detection only needs the `{\rtf` prefix match, which is unaffected by trailing null bytes. This approach:

- Does not modify the WHATWG-compliant text detection logic
- Does not change the MIME type string (`text/rtf`)
- Only affects the detection tree ordering

## Testing

```go
mimetype.Detect([]byte("{\\rtf1 Hello}"))     // text/rtf ✅
mimetype.Detect([]byte("{\\rtf1 Hello}\x00")) // text/rtf ✅ (was: application/octet-stream)
```