### PR TITLE
Add header "Message-ID" to eml hints to correctly detect type in enron email dataset

### DIFF
--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -585,6 +585,7 @@ func RFC822(raw []byte, limit uint32) bool {
 	// Some of the hints are IgnoreCase, some not. I selected based on what libmagic
 	// does and based on personal observations from sample files.
 	hints := []rfc822Hint{
+		// Enron dataset has Message-ID, Message-Id and Message-id.
 		{[]byte("Message-ID: "), scan.IgnoreCase},
 		{[]byte("From: "), 0},
 		{[]byte("To: "), 0},

--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -585,6 +585,7 @@ func RFC822(raw []byte, limit uint32) bool {
 	// Some of the hints are IgnoreCase, some not. I selected based on what libmagic
 	// does and based on personal observations from sample files.
 	hints := []rfc822Hint{
+		{[]byte("Message-ID: "), scan.IgnoreCase},
 		{[]byte("From: "), 0},
 		{[]byte("To: "), 0},
 		{[]byte("CC: "), scan.IgnoreCase},


### PR DESCRIPTION
Sometimes there may be a Message-Id in the first line in message/rfc822 mime types, which was not taken into account. There are many such emails in the enron public email dataset: https://www.cs.cmu.edu/~enron/