### PR TITLE
all: increase defaultLimit from 3072 to 4096

### DIFF
--- a/mimetype.go
+++ b/mimetype.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 )
 
-const defaultLimit uint32 = 3072
+const defaultLimit uint32 = 4096
 
 // readLimit is the maximum number of bytes from the input used when detecting.
 var readLimit uint32 = defaultLimit


### PR DESCRIPTION
4096 matches bufio.defaultBufSize and the default page size on most OSes.

https://github.com/gabriel-vasile/mimetype/actions/runs/27020629151/job/79747272193
In case benchmarks logs expire:
```
One/apk_app-metadata.properties-4   382.4n ±  1%   496.1n ±  1%   +29.73% (p=0.002 n=6)
One/apk_zipflinger-4                355.7n ±  0%   472.9n ±  5%   +32.97% (p=0.002 n=6)
One/csv-4                           178.6n ±  1%   512.2n ±  1%  +186.87% (p=0.002 n=6)
One/tsv-4                           125.6n ±  0%   462.4n ±  0%  +268.19% (p=0.002 n=6)
One/visio-4                         182.8n ±  0%   241.0n ±  0%   +31.87% (p=0.002 n=6)
One/xls-4                           130.0n ±  1%   183.8n ±  0%   +41.33% (p=0.002 n=6)
One/xlsx-4                          182.2n ±  1%   239.5n ±  1%   +31.48% (p=0.002 n=6)
```

CSV/TSV seems to be be affected most because:
- detection drops the last line from the input
- as it happens, the random generated input for the negative testcase has a newline character far from the end of the byte slice (in the 4096 case)
- when searching for a byte from the from `bytes.IndexByte` uses SIMD, but in our case we iterate bytes individually. `bytes.LastIndexByte` does not use SIMD either.