### PR TITLE
ndjson: fix edge-case with new-lines

### DIFF
--- a/internal/magic/text.go
+++ b/internal/magic/text.go
@@ -407,8 +407,16 @@ func NdJSON(raw []byte, limit uint32) bool {
 	var l scan.Bytes
 	for len(s) != 0 {
 		l = s.Line()
-		_, inspected, firstToken, _ := json.Parse(json.QueryNone, l)
-		if len(l) != inspected {
+		parsed, inspected, firstToken, _ := json.Parse(json.QueryNone, l)
+		// Only the last line may be truncated by the read limit; for it, it is
+		// enough that the parser inspected all of it. Every other line must be a
+		// complete, valid JSON document, otherwise a single JSON document spread
+		// over multiple lines would be mistaken for NDJSON. #803
+		if len(s) == 0 {
+			if inspected != len(l) {
+				return false
+			}
+		} else if parsed != len(l) {
 			return false
 		}
 		if firstToken == json.TokArray || firstToken == json.TokObject {

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -183,6 +183,10 @@ a,"b`,
 	{"xpm", "\x2F\x2A\x20\x58\x50\x4D\x20\x2A\x2F", "image/x-xpixmap", one},
 	{"js", "#!/bin/node ", "text/javascript", one},
 	{"json", `{"a":"b", "c":[{"a":"b"},1,true,false,"abc"]}`, "application/json", all},
+	{"json multiple lines", `{"a":"b",
+	"c":[{"a":"b"},
+	1,true,false,
+	"abc"]}`, "application/json", none},
 	{"json issue#239", "{\x0A\x09\x09\"key\":\"val\"}\x0A", "application/json", none},
 	// json.{int,float,string}.txt contain a single JSON value. They are valid JSON
 	// documents but they should not be detected as application/json. This mimics
@@ -250,6 +254,20 @@ a,"b`,
 		`{"key"
 		:"val"}`,
 		"application/json",
+		none,
+	},
+	{
+		"a json object spread on multiple lines second line valid json", // #803
+		`{"key":
+		"val"`, // Notice how this line is a valid json value (a string)
+		"text/plain; charset=utf-8",
+		none,
+	},
+	{
+		"a json array spread on multiple lines second line valid json", // #803
+		`{"key":
+		"val"`,
+		"text/plain; charset=utf-8",
 		none,
 	},
 	{"nes", "NES\x1a", "application/vnd.nintendo.snes.rom", one},


### PR DESCRIPTION
When a json object was truncated and spread over multiple lines, such that first line is an truncated JSON value and second one is a valid JSON value it would be reported as NdJSON. This commits makes it return text/plain.