### PR TITLE
scan: fix panic and fuzz flags

### DIFF
--- a/internal/scan/bytes.go
+++ b/internal/scan/bytes.go
@@ -228,7 +228,7 @@ func (b Bytes) Match(p []byte, flags Flags) int {
 				return -1
 			}
 			b = b[1:]
-			if !ByteIsWS(p[0]) {
+			if len(p) > 0 && !ByteIsWS(p[0]) {
 				b.TrimLWS()
 			}
 		} else {

--- a/internal/scan/bytes_test.go
+++ b/internal/scan/bytes_test.go
@@ -431,7 +431,7 @@ func FuzzSearch(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, haystack, needle []byte, flags int) {
 		b := Bytes(haystack)
-		b.Search(needle, Flags(flags)%CompactWS|IgnoreCase|FullWord)
+		b.Search(needle, Flags(flags)&(CompactWS|IgnoreCase|FullWord))
 	})
 }
 
@@ -485,6 +485,9 @@ var matchTestcases = []struct {
 	"fw+cws", "a  bc d", "a bc", FullWord | CompactWS, 5,
 }, {
 	"fw+ic+cws", "a  bc d", "A BC", FullWord | IgnoreCase | CompactWS, 5,
+}, {
+	// Pattern ending in whitespace used to panic with CompactWS.
+	"cws trailing ws in pattern", "a  ", "a ", CompactWS, 2,
 }}
 
 func TestMatch(t *testing.T) {
@@ -504,7 +507,7 @@ func FuzzMatch(f *testing.F) {
 		f.Add([]byte(tc.b), []byte(tc.p), int(tc.flags))
 	}
 	f.Fuzz(func(t *testing.T, b, p []byte, flags int) {
-		Bytes(b).Match(p, Flags(flags)%CompactWS|IgnoreCase|FullWord)
+		Bytes(b).Match(p, Flags(flags)&(CompactWS|IgnoreCase|FullWord))
 	})
 }
 


### PR DESCRIPTION
Flags used for fuzzing were constant due to a logic error. That in turn, prevented fuzzers from actually fuzzing. This commit fixes the fuzz flags and the panic.