### PR TITLE
cdf: fix slice index panic on 32bit arch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,8 @@ module github.com/gabriel-vasile/mimetype
 
 go 1.21
 
+// v1.4.14 had an int overflow causing slice index panic on 32bit arch. #829
+retract v1.4.14
+
 // v1.4.4 had a test file detected as malicious by antivirus software. #575
 retract v1.4.4

--- a/internal/cdf/cdf.go
+++ b/internal/cdf/cdf.go
@@ -385,7 +385,7 @@ func (c *cdf) readLong(sid int32, length uint32) []byte {
 			}
 			end64 := min(off64+int64(n)*int64(c.secSize), int64(len(c.data)))
 			out := c.data[off64:end64]
-			if length > 0 && int(length) < len(out) {
+			if length > 0 && int64(length) < int64(len(out)) {
 				out = out[:length]
 			}
 			return out
@@ -412,7 +412,7 @@ func (c *cdf) readLong(sid int32, length uint32) []byte {
 		}
 		sid = c.satAt(sid)
 	}
-	if length > 0 && int(length) < len(out) {
+	if length > 0 && int64(length) < int64(len(out)) {
 		out = out[:length]
 	}
 	return out
@@ -429,17 +429,18 @@ func (c *cdf) readShort(sid int32, length uint32) []byte {
 	// TODO: anyway to avoid allocating and copying the bytes?
 	out := make([]byte, 0, c.shortSecSize)
 	for sid >= 0 {
-		off := int(sid) * c.shortSecSize
-		if off+c.shortSecSize > len(sst) {
+		off64 := int64(sid) * int64(c.shortSecSize)
+		if off64+int64(c.shortSecSize) > int64(len(sst)) {
 			break // short-stream pool truncated or sid out of range
 		}
+		off := int(off64)
 		out = append(out, sst[off:off+c.shortSecSize]...)
 		if len(out) >= len(sst) {
 			break // chain longer than the pool: cyclic SSAT, stop
 		}
 		sid = c.ssatAt(sid)
 	}
-	if length > 0 && int(length) < len(out) {
+	if length > 0 && int64(length) < int64(len(out)) {
 		out = out[:length]
 	}
 	return out

--- a/internal/cdf/cdf_test.go
+++ b/internal/cdf/cdf_test.go
@@ -3,6 +3,7 @@ package cdf
 import (
 	"encoding/binary"
 	"fmt"
+	"hash/fnv"
 	"math/bits"
 	"math/rand/v2"
 	"testing"
@@ -767,8 +768,12 @@ func FuzzDetect(f *testing.F) {
 		if len(data) == 0 {
 			return
 		}
+		// Seed the rng from input so the truncation points are deterministic.
+		h := fnv.New64a()
+		h.Write(data)
+		rng := rand.New(rand.NewPCG(h.Sum64(), 0))
 		for i := 0; i < 100 && i < len(data); i++ {
-			j := rand.IntN(len(data))
+			j := rng.IntN(len(data))
 			_ = Detect(data[:j]) // must not panic on any input
 		}
 	})

--- a/internal/cdf/cdf_test.go
+++ b/internal/cdf/cdf_test.go
@@ -772,7 +772,9 @@ func FuzzDetect(f *testing.F) {
 		h := fnv.New64a()
 		h.Write(data)
 		rng := rand.New(rand.NewPCG(h.Sum64(), 0))
-		for i := 0; i < 100 && i < len(data); i++ {
+		// Truncate the data at random offsets. Truncating on each offset is
+		// too expensive.
+		for i := 0; i < 100; i++ {
 			j := rng.IntN(len(data))
 			_ = Detect(data[:j]) // must not panic on any input
 		}

--- a/mime.go
+++ b/mime.go
@@ -46,7 +46,7 @@ func (m *MIME) Extension() string {
 // Each MIME type has a non-nil parent, except for the root MIME type.
 //
 // For example, the application/json and text/html MIME types have text/plain as
-// their parent because they are text files who happen to contain JSON or HTML.
+// their parent because they are text files that happen to contain JSON or HTML.
 // Another example is the ZIP format, which is used as container
 // for Microsoft Office files, EPUB files, JAR files, and others.
 func (m *MIME) Parent() *MIME {


### PR DESCRIPTION
The cdf detection had two places where int overflows would happen and then trigger slice index panics: `readLong` and `readShort`.
<details>
  <summary>readLong</summary>
  --- FAIL: FuzzDetect (58.25s)
    --- FAIL: FuzzDetect (0.00s)
        testing.go:1927: panic: runtime error: slice bounds out of range [:4281413688] with capacity 512
            goroutine 907602 [running]:
            runtime/debug.Stack()
            	/usr/local/go/src/runtime/debug/stack.go:26 +0x83
            testing.tRunner.func1()
            	/usr/local/go/src/testing/testing.go:1927 +0x258
            panic({0x8235d80, 0x166dc480})
            	/usr/local/go/src/runtime/panic.go:860 +0x10b
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).readLong(0xa8a8bbc, 0x43, 0xff313038)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:416 +0x34d
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).readChain(0xa8a8bbc, 0x43, 0xff313038)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:453 +0x6d
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).userStream(0xa8a8bbc, {0x824b6fb, 0x13})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:489 +0xcf
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).detectFromSummary(0xa8a8bbc, {0x824b6fb, 0x13})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:126 +0x7e
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).detect(0xa8a8bbc)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:105 +0x6e
            github.com/gabriel-vasile/mimetype/internal/cdf.Detect({0x10fdea80, 0x477, 0xa80})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:37 +0x65
            github.com/gabriel-vasile/mimetype/internal/cdf.FuzzDetect.func1(0x16cea508, {0x10fdea80, 0x479, 0xa80})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf_test.go:777 +0xc1
            reflect.Value.call({0x82147e0, 0x8259000, 0x13}, {0x824719e, 0x4}, {0x16f4c2a0, 0x2, 0x2})
            	/usr/local/go/src/reflect/value.go:586 +0x9fd
            reflect.Value.Call({0x82147e0, 0x8259000, 0x13}, {0x16f4c2a0, 0x2, 0x2})
            	/usr/local/go/src/reflect/value.go:369 +0x7f
            testing.(*F).Fuzz.func1.1(0x16cea508)
            	/usr/local/go/src/testing/fuzz.go:341 +0x2ec
            testing.tRunner(0x16cea508, 0x16e6b1d0)
            	/usr/local/go/src/testing/testing.go:2036 +0x114
            created by testing.(*F).Fuzz.func1 in goroutine 20
            	/usr/local/go/src/testing/fuzz.go:328 +0x5ad

</details>
<details>
  <summary>readShort</summary>
  --- FAIL: FuzzDetect (65.76s)
    --- FAIL: FuzzDetect (0.00s)
        testing.go:1927: panic: runtime error: slice bounds out of range [:-2147483584]
            goroutine 15253 [running]:
            runtime/debug.Stack()
            	/usr/local/go/src/runtime/debug/stack.go:26 +0x83
            testing.tRunner.func1()
            	/usr/local/go/src/testing/testing.go:1927 +0x258
            panic({0x8235d80, 0x146255f0})
            	/usr/local/go/src/runtime/panic.go:860 +0x10b
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).readShort(0x167f0bbc, 0x5e000000, 0x0)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:436 +0x1d7
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).readChain(0x167f0bbc, 0x5e000000, 0x0)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:451 +0x3d
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).userStream(0x167f0bbc, {0x824b6fb, 0x13})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:489 +0xcf
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).detectFromSummary(0x167f0bbc, {0x824b6fb, 0x13})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:126 +0x7e
            github.com/gabriel-vasile/mimetype/internal/cdf.(*cdf).detect(0x167f0bbc)
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:105 +0x6e
            github.com/gabriel-vasile/mimetype/internal/cdf.Detect({0xb000000, 0x12d5, 0x63fff9c})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf.go:37 +0x65
            github.com/gabriel-vasile/mimetype/internal/cdf.FuzzDetect.func1(0x123bc008, {0xb000000, 0x17b4, 0x63fff9c})
            	/home/gabriel/Dropbox/mimetype/internal/cdf/cdf_test.go:777 +0xc1
            reflect.Value.call({0x82147e0, 0x8259000, 0x13}, {0x824719e, 0x4}, {0xae11098, 0x2, 0x2})
            	/usr/local/go/src/reflect/value.go:586 +0x9fd
            reflect.Value.Call({0x82147e0, 0x8259000, 0x13}, {0xae11098, 0x2, 0x2})
            	/usr/local/go/src/reflect/value.go:369 +0x7f
            testing.(*F).Fuzz.func1.1(0x123bc008)
            	/usr/local/go/src/testing/fuzz.go:341 +0x2ec
            testing.tRunner(0x123bc008, 0x123ae320)
            	/usr/local/go/src/testing/testing.go:2036 +0x114
            created by testing.(*F).Fuzz.func1 in goroutine 18
            	/usr/local/go/src/testing/fuzz.go:328 +0x5ad
</details>

This PR also makes the fuzz truncation for cdf deterministic.